### PR TITLE
Fix a11y issues re: image alt text & zoom

### DIFF
--- a/_includes/base/meta.html
+++ b/_includes/base/meta.html
@@ -1,7 +1,7 @@
     <meta charset="utf-8" />
     <meta content='text/html; charset=utf-8' http-equiv='Content-Type'>
     <meta http-equiv='X-UA-Compatible' content='IE=edge'>
-    <meta name='viewport' content='width=device-width, initial-scale=1.0, maximum-scale=1.0'>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 
     {% if page.excerpt %}
     <meta name="description" content="{{ page.excerpt| strip_html }}" />

--- a/_includes/base/navbar.html
+++ b/_includes/base/navbar.html
@@ -3,12 +3,12 @@
   <div class="container">
     <a class="navbar-brand" href="{{ site.baseurl }}/">
       <img src={{ "/images/android-chrome-192x192.png" | absolute_url }}
-            style="height: 100px" />
+            style="height: 100px" alt="Rush logo" />
       Rush, a monorepo manager
     </a>
     <div>
       {% for link in site.data.navigation %}
-        <a class="btn {% if link.primary %} btn-primary {% endif %}" href={{ link.url | absolute_url }}>
+        <a class="btn {% if link.primary %} btn-primary {% endif %}" href="{{ link.url | absolute_url }}">
           {{ link.text }}
         </a>
       {% endfor %}

--- a/pages/index.html
+++ b/pages/index.html
@@ -106,7 +106,7 @@ permalink: /
               <a href={{ project.url }}>
             {% endif %}
 
-              <img class="img-fluid rounded mb-3" style="height: 270" src={{ "/images/" | append: project.image | absolute_url }} alt="">
+              <img class="img-fluid rounded mb-3" style="height: 270" src={{ "/images/" | append: project.image | absolute_url }} alt="{{ project.text }} logo">
               <h5>{{ project.text }}</h5>
 
             {% if project.url %}


### PR DESCRIPTION
Two minor changes to improve accessibility if you don't mind.

1. Adds alt text to the Rush logo image currenltly flagged by [WAVE extension](http://wave.webaim.org/extension/). Fixes https://webaim.org/standards/wcag/checklist#sc1.1.1.
1. Adds alt text to `/` logos, was blank string.
1. Should only disable zoom for good reason (web games, etc.) so I think we should allow for Users to zoom their viewport. Particularly useful on mobile when Users might have a hard time reading the text content.