### PR TITLE
Add missing label for top nav search input (hidden for all but screenreaders)

### DIFF
--- a/_includes/base/top_nav.html
+++ b/_includes/base/top_nav.html
@@ -9,6 +9,7 @@
 
       <!-- SEARCH BOX - BEGIN -->
       <form action="#" class="form" style="display: inline-block; vertical-align: middle;">
+        <label class="sr-only" for="search-input">Search documentation</label>
         <input class="form-control" id="search-input" name="search" type="text" placeholder='search docs...' />
       </form>
 


### PR DESCRIPTION
## Description

The Rush website updates are great @pgonzal! 👏 

Here's a minor accessibility fix for the top nav's search input. The ARIA spec requires that a `<label>` or `aria-label` be attached to `<input>` for Users navigating a page with screen reader technology. I've added one hidden for all but screen reader Users by using Bootstrap's `.sr-only` utility class [as suggested by their documentation](https://getbootstrap.com/docs/3.3/css/#forms-inline). Alternatively this can be solved using `aria-label` on the `<input/>`.

## Testing

Below are two methods of testing this change.

### Using [Chrome's Lighthouse Audit](https://developers.google.com/web/tools/lighthouse/#devtools)

1. Run the local site and open it in Chrome
1. Open the DevTools
1. Click on the "Audits" tab
1. Run an audit. You can select "Accessibility" and de-select the rest to only run the accessibility audit.
1. The audit will output a score with errors / warnings

**Before**

![image](https://user-images.githubusercontent.com/706967/46438734-7ff70000-c713-11e8-9d04-8c290da69e15.png)

**After**

![image](https://user-images.githubusercontent.com/706967/46439811-5db2b180-c716-11e8-84f4-82c89fdcc0bc.png)

### Using WAVE Extension

1. Once installed, click the [WAVE Extension](https://wave.webaim.org/extension/) in your browser to audit the page for "Errors".

**Before**

![image](https://user-images.githubusercontent.com/706967/46429349-0eab5300-c6fb-11e8-84bf-3e3d63a69195.png)

**After**

![image](https://user-images.githubusercontent.com/706967/46438611-2ee70c00-c713-11e8-9a18-906361514e5d.png)

## References

- https://www.w3.org/TR/UNDERSTANDING-WCAG20/minimize-error-cues.html
- https://www.w3.org/WAI/tutorials/forms/labels/