### PR TITLE
Add anchor links to documentation headings for deep navigation

### DIFF
--- a/_includes/anchors.html
+++ b/_includes/anchors.html
@@ -1,0 +1,10 @@
+<script src="https://cdn.jsdelivr.net/npm/anchor-js@4.1.1/anchor.min.js"></script>
+<script>
+  document.addEventListener("DOMContentLoaded", function (e) {
+    anchors.options = {
+      class: "fa",
+      icon: "\uf0c1"
+    };
+    anchors.add();
+  });
+</script>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -49,6 +49,8 @@ layout: default
   </div>
 </div>
 
+{% include anchors.html %}
+
 <script>
 function updateScriptedSidebar() {
   let sidebar = document.getElementById('scripted-sidebar');

--- a/_sass/_docsite.scss
+++ b/_sass/_docsite.scss
@@ -93,6 +93,28 @@ article a[href*="://"]:not([href*="rushjs.io"]):not([href*="localhost"]) {
   background-image: linear-gradient(transparent,transparent),url("data:image/svg+xml,%3Csvg width%3D%2211%22 height%3D%2211%22 version%3D%221.1%22 viewBox%3D%220 0 14.364 15.028%22 xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22 xmlns%3Acc%3D%22http%3A%2F%2Fcreativecommons.org%2Fns%23%22 xmlns%3Adc%3D%22http%3A%2F%2Fpurl.org%2Fdc%2Felements%2F1.1%2F%22 xmlns%3Ardf%3D%22http%3A%2F%2Fwww.w3.org%2F1999%2F02%2F22-rdf-syntax-ns%23%22 %3E%3Cmetadata%3E%3Crdf%3ARDF%3E%3Ccc%3AWork%3E%3Cdc%3Acreator%3E%3Ccc%3AAgent%3E%3Cdc%3Atitle%3Ehttps%3A%2F%2Fgithub.com%2Fpgonzal%3C%2Fdc%3Atitle%3E%3C%2Fcc%3AAgent%3E%3C%2Fdc%3Acreator%3E%3C%2Fcc%3AWork%3E%3C%2Frdf%3ARDF%3E%3C%2Fmetadata%3E%3Cg transform%3D%22translate(-82.14 -158.93)%22 fill%3D%22%23c95228%22 %3E%3Cpath d%3D%22m83.4 161.53c-0.80824-0.0237-1.3558 0.80437-1.2464 1.5543 0.0038 3.237-0.0077 6.4743 0.0058 9.711 0.0539 0.73242 0.77982 1.2548 1.4899 1.151 3.2712-5e-3 6.543 0.01 9.8138-7e-3 0.75077-0.0663 1.2005-0.84784 1.1068-1.5494v-4.0444h-2.1993v3.4019h-8.0176v-8.0176h1.6784v-2.1994h-2.6314z%22%2F%3E%3Cpath d%3D%22m96.504 158.93c-2.5996 0.45395-5.1993 0.90791-7.7989 1.3619 0.56868 0.56868 1.1374 1.1374 1.706 1.706-1.0392 1.0392-2.0785 2.0785-3.1177 3.1177 1.0083 1.0083 2.0166 2.0166 3.025 3.025 1.0392-1.0392 2.0785-2.0785 3.1177-3.1177 0.56868 0.56868 1.1374 1.1374 1.706 1.706 0.45396-2.5996 0.90792-5.1993 1.3619-7.7989z%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E");
 }
 
+.anchorjs-link {
+  color: $gray-500;
+  font-size: 0.8em !important;
+
+  &:hover {
+    text-decoration: none;
+  }
+}
+
+// Prevents the sticky nav from covering a heading
+// that has been linked to directly via anchor links.
+:target {
+  margin-top: calc(-1 * var(--docsite-header-size));
+
+  &:before {
+    content: "";
+    display: block;
+    height: var(--docsite-header-size);
+    width: 1px;
+  }
+}
+
 html {
   height: 100%;
 }


### PR DESCRIPTION
This allows people to link directly to individual sections or headings in the docs.

![anchor-links](https://user-images.githubusercontent.com/1256329/47766116-7ecdda00-dca3-11e8-83e0-082ee8648206.gif)

**A few implementation notes:**
- This uses [AnchorJS](https://www.bryanbraun.com/anchorjs/), pulling it in via jsdelivr (the same way the js is served for the search bar)
- I noticed that this codebase was using FontAwesome so I am using FontAwesome's link icon for the heading links.
- I made a few style adjustments to accommodate the sticky nav and to ensure the icons match the look and feel of the rest of the site.
