### PR TITLE
Fix common config path and timestamp typos in documentation

### DIFF
--- a/pages/commands/rush_change.md
+++ b/pages/commands/rush_change.md
@@ -7,7 +7,7 @@ navigation_source: docs_nav
 ```
 usage: rush change [-h] [-v] [-b BRANCH]
 
-Asks a series of questions and then generates a <branchname>-<timstamp>.json
+Asks a series of questions and then generates a <branchname>-<timestamp>.json
 file in the common folder. The `publish` command will consume these files and
 perform the proper version bumps. Note these changes will eventually be
 published in a changelog.md file in each package. The possible types of

--- a/pages/configs/command_line_json.md
+++ b/pages/configs/command_line_json.md
@@ -4,7 +4,7 @@ title: command-line.json
 navigation_source: docs_nav
 ---
 
-This is the template that `rush init` generates for **./commnon/config/rush/command-line.json**:
+This is the template that `rush init` generates for **./common/config/rush/command-line.json**:
 
 ```js
 /**

--- a/pages/configs/common_versions_json.md
+++ b/pages/configs/common_versions_json.md
@@ -4,7 +4,7 @@ title: common-versions.json
 navigation_source: docs_nav
 ---
 
-This is the template that `rush init` generates for **./commnon/config/rush/common-versions.json**:
+This is the template that `rush init` generates for **./common/config/rush/common-versions.json**:
 
 ```js
 /**

--- a/pages/configs/npmrc.md
+++ b/pages/configs/npmrc.md
@@ -4,7 +4,7 @@ title: .npmrc
 navigation_source: docs_nav
 ---
 
-This is the template that `rush init` generates for **./commnon/config/rush/.npmrc**:
+This is the template that `rush init` generates for **./common/config/rush/.npmrc**:
 
 ```shell
 # Rush uses this file to configure the package registry, regardless of whether the

--- a/pages/configs/pnpmfile_js.md
+++ b/pages/configs/pnpmfile_js.md
@@ -4,7 +4,7 @@ title: pnpmfile.js
 navigation_source: docs_nav
 ---
 
-This is the template that `rush init` generates for **./commnon/config/rush/pnpmfile.js**:
+This is the template that `rush init` generates for **./common/config/rush/pnpmfile.js**:
 
 ```js
 "use strict";

--- a/pages/configs/version_policies_json.md
+++ b/pages/configs/version_policies_json.md
@@ -4,7 +4,7 @@ title: version-policies.json
 navigation_source: docs_nav
 ---
 
-This is the template that `rush init` generates for **./commnon/config/rush/version-policies.json**:
+This is the template that `rush init` generates for **./common/config/rush/version-policies.json**:
 
 ```js
 /**


### PR DESCRIPTION
Fix two typos encountered while exploring rush's documentation.

1) "commnon" in examples of rush's config path
2) "timstamp" in rush's change action manual page, also fixed in tooling https://github.com/Microsoft/web-build-tools/pull/1021

🙇 