### PR TITLE
Fix typo in doc for `rush add`

### DIFF
--- a/pages/commands/rush_add.md
+++ b/pages/commands/rush_add.md
@@ -25,8 +25,8 @@ Optional arguments:
                         be appended after an "@" sign. WARNING: Symbol
                         characters are usually interpreted by your shell, so
                         it's recommended to use quotes. For example, write
-                        "rush add --project "example@^1.2.3"" instead of
-                        "rush add --project example@^1.2.3".
+                        "rush add --package "example@^1.2.3"" instead of
+                        "rush add --package example@^1.2.3".
   --exact               If specified, the SemVer specifier added to the
                         package.json will be an exact version (e.g. without
                         tilde or caret).


### PR DESCRIPTION
Hi,
I believe `rush add --project "example@^1.2.3"` is some kind of typo.
Here's a PR to change this to `rush add --package "example@^1.2.3"`.