### PR TITLE
Fix a reference to rush version --bump

### DIFF
--- a/pages/maintainer/publishing.md
+++ b/pages/maintainer/publishing.md
@@ -100,7 +100,7 @@ You need two steps to publish your packages when version policies are used. The 
 
 `rush version --bump`
 
-Running `rush bump` will increase package versions based on their associated version policies.
+Running `rush version --bump` will increase package versions based on their associated version policies.
 
 #### Command to publish packages
 


### PR DESCRIPTION
The docs reference a non-existing `rush bump` command.
The correct command is `rush version --bump`