### PR TITLE
Fix a typo in get_started.md

### DIFF
--- a/pages/intro/get_started.md
+++ b/pages/intro/get_started.md
@@ -24,7 +24,7 @@ $ rush -h
 ```sh
 $ git clone https://github.com/microsoft/rushstack
 $ cd rushstack
-$ rush update
+$ rush install
 $ rush update  # <-- instantaneous!
 $ rush rebuild
 $ rush build    # <-- instantaneous!


### PR DESCRIPTION
There's `rush update` repeated twice. Looks like a typo.
I assume `rush install` is also valid since it's used on line 33 below.