### PR TITLE
Fix config file for implicitlyPreferredVersions

### DIFF
--- a/pages/advanced/preferred_versions.md
+++ b/pages/advanced/preferred_versions.md
@@ -135,4 +135,4 @@ For older package managers, automatically adding these entries tended to reduce 
 However, implicitly preferred versions can cause trouble for certain dependencies with incompatible `peerDependencies`
 ranges.  If you're encountering installation errors involving peer dependencies, we recommend to disable
 this behavior by setting `implicitlyPreferredVersions` to `false` in the
-[common/config/rush/experiments.json]({% link pages/configs/experiments_json.md %}) config file.
+[common/config/rush/common-versions.json]({% link pages/configs/common_versions_json.md %}) config file.


### PR DESCRIPTION
As of rush 5.17.0, the setting `implicitlyPreferredVersions` belongs in `common-versions.json` rather than `experiments.json`.

https://github.com/microsoft/rushstack/blob/master/apps/rush/CHANGELOG.md#5170