### PR TITLE
fix: name of generated file

### DIFF
--- a/pages/maintainer/add_to_repo.md
+++ b/pages/maintainer/add_to_repo.md
@@ -90,7 +90,7 @@ Since this is the first project for the repo, you'll notice that `rush update` c
 
 - **common/config/rush/shrinkwrap.yaml**: The common shrinkwrap file (here we're assuming PNPM package manager)
 - **common/scripts/install-run-rush.js**: Used by CI jobs to bootstrap the Rush tool in a reliable way
-- **common/scripts/install-run-rush.js**: Used by CI jobs to bootstrap arbitrary tools in a reliable way
+- **common/scripts/install-run.js**: Used by CI jobs to bootstrap arbitrary tools in a reliable way
 
 
 ## Step 6: Verify that the new project builds


### PR DESCRIPTION
Seems the filename was duplicated, but the comment implies it should refer to other non-rush specific file.