### PR TITLE
docs(authoring changelog): Recommend backticks

### DIFF
--- a/pages/best_practices/change_logs.md
+++ b/pages/best_practices/change_logs.md
@@ -41,7 +41,7 @@ In some workflows, a human editor will review the change logs before they are pu
 
 - When referring to public API changes, use the `()` suffix to indicate a function name, e.g. `setSomethingOnWebpart()`
 
-- When referring to public API changes, use "double-quotes" around class and property names.
+- When referring to public API changes, use `backticks (``)` around class and property names.
 
 - When documenting an upgrade, indicate the old and new version.  For example: "Upgraded `widget-library` from `1.0.2` to `2.0.1`"
 


### PR DESCRIPTION
Backticks are already used both in the other recommendation bullet points and in the examples. This change makes the recommendation consistent with the examples. This also works better with markdown's support for code-style monospaced formatting.