### PR TITLE
Correct formatting of backtick in changelog guide

### DIFF
--- a/pages/best_practices/change_logs.md
+++ b/pages/best_practices/change_logs.md
@@ -41,7 +41,7 @@ In some workflows, a human editor will review the change logs before they are pu
 
 - When referring to public API changes, use the `()` suffix to indicate a function name, e.g. `setSomethingOnWebpart()`
 
-- When referring to public API changes, use `backticks (``)` around class and property names.
+- When referring to public API changes, use backticks (`` ` ` ``) around class and property names.
 
 - When documenting an upgrade, indicate the old and new version.  For example: "Upgraded `widget-library` from `1.0.2` to `2.0.1`"
 


### PR DESCRIPTION
This is a tweak to my previous change https://github.com/microsoft/rushjs.io-website/pull/79

The website markdown to HTML renderer behaves differently from GitHub's preview when it comes to escaping backticks. I ran the site locally and got the above formatting to display as expected.