### PR TITLE
Handle semicolon-separated commands in PowerShell tab completion

### DIFF
--- a/pages/developer/tab_completion.md
+++ b/pages/developer/tab_completion.md
@@ -22,10 +22,14 @@ Add the following code to your profile:
 ```powershell
 # PowerShell parameter completion shim for the Rush CLI
 Register-ArgumentCompleter -Native -CommandName rush -ScriptBlock {
-     param($commandName, $wordToComplete, $cursorPosition)
-         rush tab-complete --position $cursorPosition --word "$wordToComplete" | ForEach-Object {
-            [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
-         }
+  param($commandName, $commandAst, $cursorPosition)
+    [string]$value = $commandAst.ToString()
+    # Handle input like `rush install; rush bui` + Tab
+    [int]$position = [Math]::Min($cursorPosition, $value.Length)
+
+    rush tab-complete --position $position --word "$value" | ForEach-Object {
+      [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
+    }
  }
 ```
 


### PR DESCRIPTION
PowerShell supports command lines like `rush install; rush build`, where the `;` separates commands. The `$cursorPosition` parameter reflects the index into the entire string, so that assumption that it is bounded by the length of the input is incorrect in PowerShell.

Bounding the value to the length of the input string gives a "good enough" approximation of the desired behavior.