### PR TITLE
Build caching disables build skipping for applicable projects

### DIFF
--- a/pages/maintainer/build_cache.md
+++ b/pages/maintainer/build_cache.md
@@ -26,6 +26,10 @@ The build cache archives are stored in two places:
   the `master` branch, the CI system builds that baseline and uploads it to cloud storage.  Even for a user who
   is doing `git clone` for the first time, their `rush build` will be very fast.
 
+> Build caching is considered a replacement for build skipping, so once enabled, commands that support
+> incremental building will begin saving and restoring from the cache instead of the previous "skipping"
+> behavior. Projects that haven't been configured for build caching, or intentionally disable build
+> caching, will continue to use the default build skipping behavior.
 
 ## Enabling the local disk cache
 


### PR DESCRIPTION
### SUMMARY

Add a note making it more clear how build caching will interact with build skipping.