### PR TITLE
Update and rename pnpmfile_js.md to .pnpmfile_cjs.md

### DIFF
--- a/pages/configs/.pnpmfile_cjs.md
+++ b/pages/configs/.pnpmfile_cjs.md
@@ -1,13 +1,13 @@
 ---
 layout: page
-title: pnpmfile.js
+title: .pnpmfile.cjs
 navigation_source: docs_nav
 ---
 
 This is the template that [rush init]({% link pages/commands/rush_init.md %})
 generates for **pnpmfile.js**:
 
-**common/config/rush/pnpmfile.js**
+**common/config/rush/.pnpmfile.cjs**
 ```js
 "use strict";
 


### PR DESCRIPTION
See https://rushstack.zulipchat.com/#narrow/stream/262513-general/topic/.E2.9C.94.20pnpmfile.2Ejs.20is.20unrecognized/near/252645331

(incidentally, this was changed in the main repo four months ago: https://github.com/microsoft/rushstack/commit/c74d8de61d829f254d57eb7effbedaf5f895feb1) - given rush is a monorepo tool, shouldn't the website be in there too?? Might be a nice way to show off `rush deploy` type commands too. 