### PR TITLE
Fix spelling of npm (and pnpm)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -60,7 +60,7 @@
 *.yml             text eol=crlf
 *.xml             text eol=crlf
 
-# NPM "bin" scripts MUST have LF, or else the executable fails to run on Mac.
+# npm "bin" scripts MUST have LF, or else the executable fails to run on Mac.
 # This fnmatch expression only matches files in a "bin" folder and without
 # a period in the filename.
 /*/*/bin/+([!.]) -text

--- a/_data/navigation.yaml
+++ b/_data/navigation.yaml
@@ -53,7 +53,7 @@ docs_nav:
         url: /pages/maintainer/enabling_ci_builds
       - title: Recommended Settings
         url: /pages/maintainer/recommended_settings
-      - title: npm vs PNPM vs Yarn
+      - title: npm vs pnpm vs Yarn
         url: /pages/maintainer/package_managers
       - title: Enabling policies
         url: /pages/maintainer/setup_policies

--- a/_data/navigation.yaml
+++ b/_data/navigation.yaml
@@ -53,7 +53,7 @@ docs_nav:
         url: /pages/maintainer/enabling_ci_builds
       - title: Recommended Settings
         url: /pages/maintainer/recommended_settings
-      - title: NPM vs PNPM vs Yarn
+      - title: npm vs PNPM vs Yarn
         url: /pages/maintainer/package_managers
       - title: Enabling policies
         url: /pages/maintainer/setup_policies
@@ -69,7 +69,7 @@ docs_nav:
         url: /pages/maintainer/deploying
       - title: Enabling the build cache
         url: /pages/maintainer/build_cache
-      - title: NPM registry authentication
+      - title: npm registry authentication
         url: /pages/maintainer/npm_registry_auth
 
   - title: Best practices
@@ -83,7 +83,7 @@ docs_nav:
         url: /pages/advanced/config_files
       - title: Phantom dependencies
         url: /pages/advanced/phantom_deps
-      - title: NPM doppelgangers
+      - title: npm doppelgangers
         url: /pages/advanced/npm_doppelgangers
       - title: Preferred versions
         url: /pages/advanced/preferred_versions

--- a/pages/advanced/api.md
+++ b/pages/advanced/api.md
@@ -44,7 +44,7 @@ const rushConfiguration = rushLib.RushConfiguration.loadFromDefaultLocation({
   startingFolder: process.cwd()
 });
 
-// This will find "@rushstack/ts-command-line" in rush.json, without needing to specify the NPM scope
+// This will find "@rushstack/ts-command-line" in rush.json, without needing to specify the npm scope
 const project = rushConfiguration.findProjectByShorthandName('ts-command-line');
 
 // Add lodash as an optional dependency

--- a/pages/advanced/config_files.md
+++ b/pages/advanced/config_files.md
@@ -14,7 +14,7 @@ navigation_source: docs_nav
 | common/changes/...                       | Storage for the `rush change` command |
 | common/config/rush/.npmrc                | If you need custom settings for "npm install" (e.g. npm registry mappings), put them in this file.  Rush will copy this file into the **common/temp/** folder. |
 | common/config/rush/npm-shrinkwrap.json  | The shrinkwrap file when your package manager is npm.  This is the common shrinkwrap file that applies to all projects in the Rush repo. For more information, see **"What is this "shrinkwrap file"** in the [Everyday commands]({% link pages/developer/everyday_commands.md %}) section. |
-| common/config/rush/shrinkwrap.yaml | The shrinkwrap file when your package manager is PNPM. |
+| common/config/rush/shrinkwrap.yaml | The shrinkwrap file when your package manager is pnpm. |
 | common/config/rush/yarn.lock   | The shrinkwrap file when your package manager is Yarn. |
 | common/config/rush/command-line.json  | Used to define [custom commands]({% link pages/maintainer/custom_commands.md %}). |
 | common/config/rush/browser-approved-packages.json   | Used by the **approvedPackagesPolicy** setting from rush.json |

--- a/pages/advanced/config_files.md
+++ b/pages/advanced/config_files.md
@@ -12,8 +12,8 @@ navigation_source: docs_nav
 | :--------------------------------------- | :------------------------------ |
 | rush.json                                | The main configuration file for Rush |
 | common/changes/...                       | Storage for the `rush change` command |
-| common/config/rush/.npmrc                | If you need custom settings for "npm install" (e.g. NPM registry mappings), put them in this file.  Rush will copy this file into the **common/temp/** folder. |
-| common/config/rush/npm-shrinkwrap.json  | The shrinkwrap file when your package manager is NPM.  This is the common shrinkwrap file that applies to all projects in the Rush repo. For more information, see **"What is this "shrinkwrap file"** in the [Everyday commands]({% link pages/developer/everyday_commands.md %}) section. |
+| common/config/rush/.npmrc                | If you need custom settings for "npm install" (e.g. npm registry mappings), put them in this file.  Rush will copy this file into the **common/temp/** folder. |
+| common/config/rush/npm-shrinkwrap.json  | The shrinkwrap file when your package manager is npm.  This is the common shrinkwrap file that applies to all projects in the Rush repo. For more information, see **"What is this "shrinkwrap file"** in the [Everyday commands]({% link pages/developer/everyday_commands.md %}) section. |
 | common/config/rush/shrinkwrap.yaml | The shrinkwrap file when your package manager is PNPM. |
 | common/config/rush/yarn.lock   | The shrinkwrap file when your package manager is Yarn. |
 | common/config/rush/command-line.json  | Used to define [custom commands]({% link pages/maintainer/custom_commands.md %}). |
@@ -29,9 +29,9 @@ navigation_source: docs_nav
 | :--------------------------------------- | :------------------------------ |
 | common/temp/install-run/...             | Storage for the **install-run.js** and **install-run-rush.js** scripts. See [Enabling CI builds]({% link pages/maintainer/enabling_ci_builds.md %}). |
 | common/temp/node_modules/...             | The installed packages.  This is a plain old `npm install` output, with no symlinks in this tree. |
-| common/temp/npm-cache/...                | A local NPM cache will be created here.  Rush does not use the global NPM cache due to its concurrency problems. |
-| common/temp/npm-local/...                | Based on the **npmVersion** setting, Rush will install NPM in your home directory and create a symlink to it for each repo that requests it. |
-| common/temp/npm-tmp/...                  | Temporary files created by NPM during installation. |
+| common/temp/npm-cache/...                | A local npm cache will be created here.  Rush does not use the global npm cache due to its concurrency problems. |
+| common/temp/npm-local/...                | Based on the **npmVersion** setting, Rush will install npm in your home directory and create a symlink to it for each repo that requests it. |
+| common/temp/npm-tmp/...                  | Temporary files created by npm during installation. |
 | common/temp/projects/...                 | Synthetic projects referenced by **common/temp/package.json**. |
 | common/temp/rush-recycler/...            | Used to speed up recursive deletes. |
 | common/temp/last-install.flag            | Don't worry about this file.  It tracks the timestamp of the last successful `rush install`. |

--- a/pages/advanced/incremental_builds.md
+++ b/pages/advanced/incremental_builds.md
@@ -8,7 +8,7 @@ Rush's **incremental build** feature speeds things up by skipping projects that 
 In this context, "already up to date" means:
 
 1. the project has already been built locally, AND
-2. its source files and NPM dependencies have not changed since then, AND
+2. its source files and npm dependencies have not changed since then, AND
 3. if the project depends on any other Rush projects, those projects are up to date as well, AND
 4. the command line parameters haven't changed.  (For example, invoking `rush build --production`
    after `rush build` would require rebuilding.)
@@ -66,7 +66,7 @@ Suppose hypothetically that our monorepo has the following projects:
 
 <img src="/images/docs/selection-intro.svg" alt="a sample monorepo" style="height: 150px;" />
 
-In the above illustration, the circles represent local projects, not external NPM dependencies.
+In the above illustration, the circles represent local projects, not external npm dependencies.
 The arrow from `D` to `C` indicates that `D` depends on `C`; this means that `C` must be built before
 `D` can be built.
 

--- a/pages/advanced/installation_variants.md
+++ b/pages/advanced/installation_variants.md
@@ -86,7 +86,7 @@ to your variant folder **common/config/rush/variants/old-widget-sdk**.   Three c
 
 - **shrinkwrap.yaml**, **npm-shrinkwrap.json**, or **yarn.lock** depending on your package manager
 - **common-versions.json**
-- **pnpmfile.js** if you are using PNPM as your package manager
+- **pnpmfile.js** if you are using pnpm as your package manager
 
 Be sure to add the copied files to Git:
 ```shell

--- a/pages/advanced/npm_doppelgangers.md
+++ b/pages/advanced/npm_doppelgangers.md
@@ -1,13 +1,13 @@
 ---
 layout: page
-title: NPM doppelgangers
+title: npm doppelgangers
 navigation_source: docs_nav
 ---
 
 *This article continues the discussion from the "[Phantom dependencies]({% link pages/advanced/phantom_deps.md %})" section.  It's recommended to read that first.*
 
-## How NPM doppelgangers arise
-<img src="/images/home/card-doppel.svg" style="float: right; padding-left: 30px" alt="NPM doppelganger" />
+## How npm doppelgangers arise
+<img src="/images/home/card-doppel.svg" style="float: right; padding-left: 30px" alt="npm doppelganger" />
 
 Sometimes the **node_modules** data structure is forced to install two copies
 of ***the same version of*** the same package.  Really?  How can that happen?
@@ -122,7 +122,7 @@ but then **F1** gets duplicated:
 Either way, we cannot arrange the tree without having two copies of the same version
 of **library-f**.  We call these "doppelgangers".  Traditional package managers from
 other programming languages don't encounter this issue; it's a peculiar aspect of
-NPM's **node_modules** tree.  It is inherent in the design and unavoidable.
+npm's **node_modules** tree.  It is inherent in the design and unavoidable.
 
 
 ## Consequences of doppelgangers
@@ -171,7 +171,7 @@ scale monorepo.  Here's some potential problems that can result:
   lead to highly confusing compiler errors.
 
 **How Rush helps:** Rush's symlinking strategy eliminates doppelgangers only for dependencies
-that are local projects in the monorepo.  If you're using NPM or Yarn as your package manager,
+that are local projects in the monorepo.  If you're using npm or Yarn as your package manager,
 unfortunately doppelgangers are still possible for any indirect dependencies.  Whereas if you
 use PNPM with Rush, the doppelganger problem is fully solved (because PNPM's installation model
 accurately simulates a true directed acyclic graph).

--- a/pages/advanced/npm_doppelgangers.md
+++ b/pages/advanced/npm_doppelgangers.md
@@ -173,5 +173,5 @@ scale monorepo.  Here's some potential problems that can result:
 **How Rush helps:** Rush's symlinking strategy eliminates doppelgangers only for dependencies
 that are local projects in the monorepo.  If you're using npm or Yarn as your package manager,
 unfortunately doppelgangers are still possible for any indirect dependencies.  Whereas if you
-use PNPM with Rush, the doppelganger problem is fully solved (because PNPM's installation model
+use pnpm with Rush, the doppelganger problem is fully solved (because pnpm's installation model
 accurately simulates a true directed acyclic graph).

--- a/pages/advanced/phantom_deps.md
+++ b/pages/advanced/phantom_deps.md
@@ -20,8 +20,8 @@ a "**diamond dependency**" between these four packages.  Conventionally the prog
 **module resolver** looks up imported packages by traversing edges of this graph, and
 (in other systems) the packages themselves are found in a central store that can be shared by many projects.
 
-For historical reasons, NodeJS and NPM took a different approach by representing this graph physically on disk:
-NPM models the graph vertexes using actual package folder copies, and the graph edges are implied by the
+For historical reasons, NodeJS and npm took a different approach by representing this graph physically on disk:
+npm models the graph vertexes using actual package folder copies, and the graph edges are implied by the
 subfolder relationships.  But a folder tree's branches cannot rejoin to make diamonds.
 To handle this, NodeJS added a [special resolution rule](https://nodejs.org/api/modules.html#modules_all_together)
 whose effect is to introduce extra graph edges (pointing to the immediate children of all parent folders).
@@ -31,13 +31,13 @@ From a computer science perspective, this rule relaxes the file system's
 extra edges that do not correspond to any declared package dependency.  These extra edges are called
 "**phantom dependencies**".
 
-NPM's approach has many unique characteristics that differ from traditional package managers:
+npm's approach has many unique characteristics that differ from traditional package managers:
 
 - Each (root-level) project gets its own **node_modules** tree containing lots of package folder copies.
   Even a very small NodeJS project is likely to have more than 10,000 files copied under its folder.
 
-- In NPM 2.x, the **node_modules** folder tree was very deep and duplicated, which minimized phantom dependencies.
-  NPM 3.x improved the installation algorithm to flatten the tree, which eliminated a lot of duplication, at the
+- In npm 2.x, the **node_modules** folder tree was very deep and duplicated, which minimized phantom dependencies.
+  npm 3.x improved the installation algorithm to flatten the tree, which eliminated a lot of duplication, at the
   expense of introducing even more phantom dependencies (extra graph edges).  In some cases the new algorithm will
   also choose a slightly older version of a package (while still satisfying SemVer) to further reduce duplication
   of package folders.
@@ -45,7 +45,7 @@ NPM's approach has many unique characteristics that differ from traditional pack
 - The installed **node_modules** tree is not unique.  There are many possible ways to arrange
   package folders into a tree to approximate the directed acyclic graph, and there is no
   unique "normalized" arrangement.  The tree you get depends on whatever heuristics your
-  package manager chose to follow.  NPM's own heuristics are even sensitive to
+  package manager chose to follow.  npm's own heuristics are even sensitive to
   [the order in which you add packages](http://npm.github.io/how-npm-works-docs/npm3/non-determinism.html).
 
 
@@ -56,7 +56,7 @@ things -- mitigating these problems was one of the original motivations for crea
 
 
 ## Phantom dependencies
-<img src="/images/home/card-phantom.svg" style="float: right; padding-left: 30px" alt="NPM phantom dependency" />
+<img src="/images/home/card-phantom.svg" style="float: right; padding-left: 30px" alt="npm phantom dependency" />
 
 A "phantom dependency" occurs when a project uses a package that is not defined
 in its **package.json** file.  Consider this example:
@@ -90,7 +90,7 @@ var glob = require("glob")  // ???
 Wait a sec -- two of these libraries are not declared as dependencies
 in the **package.json** file.  How is this working at all!?  It turns out that
 **brace-expansion** is a dependency of **minimatch**, and **glob** is a dependency
-of **rimraf**.  During installation, NPM has flattened their folders to be under
+of **rimraf**.  During installation, npm has flattened their folders to be under
 **my-library/node_modules**.  The NodeJS `require()` function finds them there
 because it probes for folders without considering the **package.json** files at all.
 This is perhaps counterintuitive, but it seems to work just fine.  Maybe it's a
@@ -179,4 +179,4 @@ potential parent folders and issues a warning if any phantom **node_modules** fo
 are found.
 
 
-#### Next up: [NPM doppelgangers]({% link pages/advanced/npm_doppelgangers.md %})
+#### Next up: [npm doppelgangers]({% link pages/advanced/npm_doppelgangers.md %})

--- a/pages/advanced/phantom_deps.md
+++ b/pages/advanced/phantom_deps.md
@@ -120,7 +120,7 @@ It can lead to unexpected malfunctions or errors:
 
 **How Rush helps:** Rush's symlinking strategy ensures that each project's **node_modules**
 contains only its declared direct dependencies.  This catches phantom dependencies
-immediately at build time.  If you're using the PNPM package manager, the same protections
+immediately at build time.  If you're using the pnpm package manager, the same protections
 are also applied to all indirect dependencies (with the ability to workaround any "bad" packages
 by using **pnpmfile.js**).
 

--- a/pages/advanced/preferred_versions.md
+++ b/pages/advanced/preferred_versions.md
@@ -22,7 +22,7 @@ Rush performs a single install for all your projects by creating a fake **rush-c
 }
 ```
 
-The package manager considers each of these "**@rush-temp**" scoped projects to be a direct dependency for the **rush-common** project. In general NPM installs a project's direct dependencies first (at the root of the **node_modules** tree), and only then proceed to download the indirect dependencies.  But since your real project's direct dependencies are now indirect dependencies for the **rush-common** project, the `npm install` behavior could be different.
+The package manager considers each of these "**@rush-temp**" scoped projects to be a direct dependency for the **rush-common** project. In general npm installs a project's direct dependencies first (at the root of the **node_modules** tree), and only then proceed to download the indirect dependencies.  But since your real project's direct dependencies are now indirect dependencies for the **rush-common** project, the `npm install` behavior could be different.
 
 Suppose **project-1/package.json** looks like this:
 
@@ -49,7 +49,7 @@ And let's say **library-a** (from the internet) looks like this:
 }
 ```
 
-If you ran a normal `npm install` in for **project-1**, you would expect to have a **node_modules** folder which looks like this, even if **library-b@1.4.4** exists in the NPM registry:
+If you ran a normal `npm install` in for **project-1**, you would expect to have a **node_modules** folder which looks like this, even if **library-b@1.4.4** exists in the npm registry:
 
 ```
 node_modules/
@@ -57,7 +57,7 @@ node_modules/
   library-b/ (1.1.3)
 ```
 
-Even though **library-b@1.4.4** matches the `"^1.0.0"` SemVer pattern, NPM doesn't install it because 1.1.3 (installed by `project-1`) already satisfies it.
+Even though **library-b@1.4.4** matches the `"^1.0.0"` SemVer pattern, npm doesn't install it because 1.1.3 (installed by `project-1`) already satisfies it.
 
 But the **common/temp/package.json** described above would not guarantee this. Instead, depending on the dependencies of **project-2**, you could end up with this:
 
@@ -69,7 +69,7 @@ node_modules/
   library-b/ (1.4.4)
 ```
 
-... which is also a valid solution to the SemVer equation.  Similar problems can arise when using Rush with NPM's [peer dependencies](https://nodejs.org/en/blog/npm/peer-dependencies/).
+... which is also a valid solution to the SemVer equation.  Similar problems can arise when using Rush with npm's [peer dependencies](https://nodejs.org/en/blog/npm/peer-dependencies/).
 
 ## Preferred Versions
 
@@ -103,7 +103,7 @@ This will cause **css-loader** to be added to the **common/temp/package.json** f
 }
 ```
 
-*Note: If you are publishing packages, you should be careful about adding preferred versions in a way that would produce a different result than a person who installs your library normally using NPM.*
+*Note: If you are publishing packages, you should be careful about adding preferred versions in a way that would produce a different result than a person who installs your library normally using npm.*
 
 ## Implicitly Preferred Versions
 

--- a/pages/advanced/watch_mode.md
+++ b/pages/advanced/watch_mode.md
@@ -21,7 +21,7 @@ Suppose hypothetically that our monorepo has the following projects:
 
 <img src="/images/docs/selection-intro.svg" alt="a sample monorepo" style="height: 150px;" />
 
-In the above illustration, the circles represent local projects, not external NPM dependencies.
+In the above illustration, the circles represent local projects, not external npm dependencies.
 The arrow from `D` to `C` indicates that `D` depends on `C`; this means that `C` must be built before
 `D` can be built.
 

--- a/pages/best_practices/change_logs.md
+++ b/pages/best_practices/change_logs.md
@@ -4,7 +4,7 @@ title: Authoring change logs
 navigation_source: docs_nav
 ---
 
-When publishing an NPM package, it is common practice to include a [CHANGELOG.md](https://github.com/microsoft/rushstack/blob/master/libraries/node-core-library/CHANGELOG.md) file to inform your consumers about bug fixes, new features, and changed or removed functionality. Rush automates this using the [rush change]({% link pages/commands/rush_change.md %}) command. This command should be run once you are ready to merge your PR, after all your changes have been committed to the branch. It analyzes the changes in your branch and (when necessary) prompts you to write human-readable descriptions of your changes.
+When publishing an npm package, it is common practice to include a [CHANGELOG.md](https://github.com/microsoft/rushstack/blob/master/libraries/node-core-library/CHANGELOG.md) file to inform your consumers about bug fixes, new features, and changed or removed functionality. Rush automates this using the [rush change]({% link pages/commands/rush_change.md %}) command. This command should be run once you are ready to merge your PR, after all your changes have been committed to the branch. It analyzes the changes in your branch and (when necessary) prompts you to write human-readable descriptions of your changes.
 
 The way in which you phrase your description is important. You don't want to be overly concise or specific, you don't want to reveal private information, and you want the description to be as helpful as possible.  We recommend to err on the side of readability.  Ask yourself:
 

--- a/pages/commands/rush_build.md
+++ b/pages/commands/rush_build.md
@@ -17,7 +17,7 @@ an incremental build. In other words, it only builds projects whose source
 files have changed since the last successful build. The analysis requires a
 Git working tree, and only considers source files that are tracked by Git and
 whose path is under the project folder. (For more details about this
-algorithm, see the documentation for the "package-deps-hash" NPM package.)
+algorithm, see the documentation for the "package-deps-hash" npm package.)
 The incremental build state is tracked in a per-project folder called ".
 rush/temp" which should NOT be added to Git. The build command is tracked by
 the "arguments" field in the "package-deps_build.json" file contained

--- a/pages/commands/rush_init-autoinstaller.md
+++ b/pages/commands/rush_init-autoinstaller.md
@@ -16,7 +16,7 @@ Optional arguments:
   -h, --help            Show this help message and exit.
   --name AUTOINSTALLER_NAME
                         Specifies the name of the autoinstaller folder, which
-                        must conform to the naming rules for NPM packages.
+                        must conform to the naming rules for npm packages.
 ```
 
 ## See also

--- a/pages/commands/rush_publish.md
+++ b/pages/commands/rush_publish.md
@@ -35,7 +35,7 @@ Optional arguments:
                         Regenerates all changelog files based on the current
                         JSON content.
   -r REGISTRY, --registry REGISTRY
-                        Publishes to a specified NPM registry. If this is
+                        Publishes to a specified npm registry. If this is
                         specified, it will prevent the current commit will
                         not be tagged.
   -n TOKEN, --npm-auth-token TOKEN
@@ -46,7 +46,7 @@ Optional arguments:
                         safer practice is to pass the token via an
                         environment variable and reference it from your
                         common/config/rush/.npmrc-publish file.
-  -t TAG, --tag TAG     The tag option to pass to npm publish. By default NPM
+  -t TAG, --tag TAG     The tag option to pass to npm publish. By default npm
                         will publish using the 'latest' tag, even if the
                         package is older than the current latest, so in
                         publishing workflows for older releases, providing a
@@ -57,15 +57,15 @@ Optional arguments:
                         publish scoped packages with an access level of
                         "restricted". Scoped packages can be published with
                         an access level of "public" by specifying that value
-                        for this flag with the initial publication. NPM
+                        for this flag with the initial publication. npm
                         always publishes unscoped packages with an access
-                        level of "public". For more information, see the NPM
+                        level of "public". For more information, see the npm
                         documentation for the "--access" option of "npm
                         publish".
   --pack                Packs projects into tarballs instead of publishing to
                         npm repository. It can only be used when
                         --include-all is specified. If this flag is specified,
-                         NPM registry related parameters will be ignored.
+                         npm registry related parameters will be ignored.
   --release-folder FOLDER
                         This parameter is used with --pack parameter to
                         provide customized location for the tarballs instead

--- a/pages/commands/rush_scan.md
+++ b/pages/commands/rush_scan.md
@@ -7,7 +7,7 @@ navigation_source: docs_nav
 ```
 usage: rush scan [-h]
 
-The Node.js module system allows a project to import NPM packages without
+The Node.js module system allows a project to import npm packages without
 explicitly declaring them as dependencies in the package.json file. Such
 "phantom dependencies" can cause problems. Rush and PNPM use symlinks
 specifically to protect against phantom dependencies. These protections may

--- a/pages/commands/rush_scan.md
+++ b/pages/commands/rush_scan.md
@@ -9,7 +9,7 @@ usage: rush scan [-h]
 
 The Node.js module system allows a project to import npm packages without
 explicitly declaring them as dependencies in the package.json file. Such
-"phantom dependencies" can cause problems. Rush and PNPM use symlinks
+"phantom dependencies" can cause problems. Rush and pnpm use symlinks
 specifically to protect against phantom dependencies. These protections may
 cause runtime errors for existing projects when they are first migrated into
 a Rush monorepo. The "rush scan" command is a handy tool for fixing these

--- a/pages/commands/rush_setup.md
+++ b/pages/commands/rush_setup.md
@@ -9,7 +9,7 @@ usage: rush setup [-h]
 
 (EXPERIMENTAL) Invoke this command before working in a new repo to ensure
 that any required prerequisites are installed and permissions are configured.
-The initial implementation configures the NPM registry credentials. More
+The initial implementation configures the npm registry credentials. More
 features will be added later.
 
 Optional arguments:

--- a/pages/commands/rush_unlink.md
+++ b/pages/commands/rush_unlink.md
@@ -9,7 +9,7 @@ usage: rush unlink [-h]
 
 This removes the symlinks created by the "rush link" command. This is useful
 for cleaning a repo using "git clean" without accidentally deleting source
-files, or for using standard NPM commands on a project.
+files, or for using standard npm commands on a project.
 
 Optional arguments:
   -h, --help  Show this help message and exit.

--- a/pages/configs/artifactory_json.md
+++ b/pages/configs/artifactory_json.md
@@ -18,7 +18,7 @@ generates for **artifactory.json**:
 
   "packageRegistry": {
     /**
-     * (Required) Set this to "true" to enable Rush to manage tokens for an Artifactory NPM registry.
+     * (Required) Set this to "true" to enable Rush to manage tokens for an Artifactory npm registry.
      * When enabled, "rush install" will automatically detect when the user's ~/.npmrc
      * authentication token is missing or expired.  And "rush setup" will prompt the user to
      * renew their token.
@@ -28,7 +28,7 @@ generates for **artifactory.json**:
     "enabled": false,
 
     /**
-     * (Required) Specify the URL of your NPM registry.  This is the same URL that appears in
+     * (Required) Specify the URL of your npm registry.  This is the same URL that appears in
      * your .npmrc file.  It should look something like this example:
      *
      *   https://your-company.jfrog.io/your-project/api/npm/npm-private/
@@ -38,7 +38,7 @@ generates for **artifactory.json**:
     /**
      * A list of custom strings that "rush setup" should add to the user's ~/.npmrc file at the time
      * when the token is updated.  This could be used for example to configure the company registry
-     * to be used whenever NPM is invoked as a standalone command (but it's not needed for Rush
+     * to be used whenever npm is invoked as a standalone command (but it's not needed for Rush
      * operations like "rush add" and "rush install", which get their mappings from the monorepo's
      * common/config/rush/.npmrc file).
      *
@@ -65,7 +65,7 @@ generates for **artifactory.json**:
     "messageOverrides": {
       /**
        * Overrides the message that normally says:
-       * "This monorepo consumes packages from an Artifactory private NPM registry."
+       * "This monorepo consumes packages from an Artifactory private npm registry."
        */
       // "introduction": "",
 
@@ -102,4 +102,4 @@ generates for **artifactory.json**:
 
 ## See also
 
-- [NPM registry authentication]({% link pages/maintainer/npm_registry_auth.md %})
+- [npm registry authentication]({% link pages/maintainer/npm_registry_auth.md %})

--- a/pages/configs/command-line_json.md
+++ b/pages/configs/command-line_json.md
@@ -158,10 +158,10 @@ generates for **command-line.json**:
     //   "shellCommand": "node common/scripts/my-global-command.js",
     //
     //   /**
-    //    * If your "shellCommand" script depends on NPM packages, the recommended best practice is
+    //    * If your "shellCommand" script depends on npm packages, the recommended best practice is
     //    * to make it into a regular Rush project that builds using your normal toolchain.  In cases where
     //    * the command needs to work without first having to run "rush build", the recommended practice
-    //    * is to publish the project to an NPM registry and use common/scripts/install-run.js to launch it.
+    //    * is to publish the project to an npm registry and use common/scripts/install-run.js to launch it.
     //    *
     //    * Autoinstallers offer another possibility: They are folders under "common/autoinstallers" with
     //    * a package.json file and shrinkwrap file. Rush will automatically invoke the package manager to
@@ -170,7 +170,7 @@ generates for **command-line.json**:
     //    * good solution for Git hook scripts.  But they have the disadvantages of not being buildable
     //    * projects, and of increasing the overall installation footprint for your monorepo.
     //    *
-    //    * The "autoinstallerName" setting must not contain a path and must be a valid NPM package name.
+    //    * The "autoinstallerName" setting must not contain a path and must be a valid npm package name.
     //    * For example, the name "my-task" would map to "common/autoinstallers/my-task/package.json", and
     //    * the "common/autoinstallers/my-task/node_modules/.bin" folder would be added to the shell PATH when
     //    * invoking the "shellCommand".

--- a/pages/configs/common-versions_json.md
+++ b/pages/configs/common-versions_json.md
@@ -24,7 +24,7 @@ generates for **common-versions.json**:
    * The "preferredVersions" value can be any SemVer range specifier (e.g. "~1.2.3").  Rush injects these values into
    * the "dependencies" field of the top-level common/temp/package.json, which influences how the package manager
    * will calculate versions.  The specific effect depends on your package manager.  Generally it will have no
-   * effect on an incompatible or already constrained SemVer range.  If you are using PNPM, similar effects can be
+   * effect on an incompatible or already constrained SemVer range.  If you are using pnpm, similar effects can be
    * achieved using the pnpmfile.js hook.  See the Rush documentation for more details.
    *
    * After modifying this field, it's recommended to run "rush update --full" so that the package manager

--- a/pages/configs/common-versions_json.md
+++ b/pages/configs/common-versions_json.md
@@ -11,14 +11,14 @@ generates for **common-versions.json**:
 **common/config/rush/common-versions.json**
 ```js
 /**
- * This configuration file specifies NPM dependency version selections that affect all projects
+ * This configuration file specifies npm dependency version selections that affect all projects
  * in a Rush repo.  More documentation is available on the Rush website: https://rushjs.io
  */
 {
   "$schema": "https://developer.microsoft.com/json-schemas/rush/v5/common-versions.schema.json",
 
   /**
-   * A table that specifies a "preferred version" for a given NPM package.  This feature is typically used
+   * A table that specifies a "preferred version" for a given npm package.  This feature is typically used
    * to hold back an indirect dependency to a specific older version, or to reduce duplication of indirect dependencies.
    *
    * The "preferredVersions" value can be any SemVer range specifier (e.g. "~1.2.3").  Rush injects these values into

--- a/pages/configs/deploy_json.md
+++ b/pages/configs/deploy_json.md
@@ -49,7 +49,7 @@ generates for **deploy.json** and **deploy-&lt;scenario name&gt;>.json**:
   // "includeNpmIgnoreFiles": true,
 
   /**
-   * To improve backwards compatibility with legacy packages, the PNPM package manager installs extra links in the
+   * To improve backwards compatibility with legacy packages, the pnpm package manager installs extra links in the
    * node_modules folder that enable packages to import undeclared dependencies.  In some cases this workaround may
    * double the number of links created.  If your deployment does not require this workaround, you can set
    * "omitPnpmWorkaroundLinks" to true to avoid creating the extra links.

--- a/pages/configs/deploy_json.md
+++ b/pages/configs/deploy_json.md
@@ -20,7 +20,7 @@ generates for **deploy.json** and **deploy-&lt;scenario name&gt;>.json**:
 
   /**
    * The "rush deploy" command prepares a deployment folder, starting from the main project and collecting
-   * all of its dependencies (both NPM packages and other Rush projects).  The main project is specified
+   * all of its dependencies (both npm packages and other Rush projects).  The main project is specified
    * using the "--project" parameter.  The "deploymentProjectNames" setting lists the allowable choices for
    * the "--project" parameter; this documents the intended deployments for your monorepo and helps validate
    * that "rush deploy" is invoked correctly.  If there is only one item in the "deploymentProjectNames" array,

--- a/pages/configs/environment_vars.md
+++ b/pages/configs/environment_vars.md
@@ -92,8 +92,8 @@ For more information, see the command-line help for the `--parallelism` paramete
 
 ## RUSH_PNPM_STORE_PATH
 
-When using PNPM as the package manager, this variable can be used to configure the path that
-PNPM will use as the store directory.
+When using pnpm as the package manager, this variable can be used to configure the path that
+pnpm will use as the store directory.
 
 If a relative path is used, then the store path will be resolved relative to the process's
 current working directory. An absolute path is recommended.

--- a/pages/configs/npmrc.md
+++ b/pages/configs/npmrc.md
@@ -10,7 +10,7 @@ generates for the monorepo **.npmrc** file:
 **common/config/rush/.npmrc**
 ```shell
 # Rush uses this file to configure the npm package registry during installation.  It is applicable
-# to PNPM, npm, and Yarn package managers.  It is used by operations such as "rush install",
+# to pnpm, npm, and Yarn package managers.  It is used by operations such as "rush install",
 # "rush update", and the "install-run.js" scripts.
 #
 # NOTE: The "rush publish" command uses .npmrc-publish instead.

--- a/pages/configs/npmrc.md
+++ b/pages/configs/npmrc.md
@@ -9,8 +9,8 @@ generates for the monorepo **.npmrc** file:
 
 **common/config/rush/.npmrc**
 ```shell
-# Rush uses this file to configure the NPM package registry during installation.  It is applicable
-# to PNPM, NPM, and Yarn package managers.  It is used by operations such as "rush install",
+# Rush uses this file to configure the npm package registry during installation.  It is applicable
+# to PNPM, npm, and Yarn package managers.  It is used by operations such as "rush install",
 # "rush update", and the "install-run.js" scripts.
 #
 # NOTE: The "rush publish" command uses .npmrc-publish instead.
@@ -37,10 +37,10 @@ always-auth=false
 
 Regular Rush operations perform the following lookup:
 
-1. To support unusual situations, NPM config environment variables take precedence over any **.npmrc** settings.
+1. To support unusual situations, npm config environment variables take precedence over any **.npmrc** settings.
    The environment variable name is prefixed by `npm_config_`.  For example, setting the `npm_config_registry`
    variable will override the `registry` setting in **.npmrc**.  Nonstandard name patterns like
-   `npm_config_@example:registry` are also accepted by NPM's design.
+   `npm_config_@example:registry` are also accepted by npm's design.
 2. Typically settings come from a temporary **.npmrc** file that Rush copies into the working directory
    for the operation.  The file is copied from **common/config/rush/.npmrc**, but omitting any lines that
    reference undefined environment variables (as explained above).  For most operations, the working directory
@@ -62,5 +62,5 @@ additional **.npmrc** files.
 
 ## See also
 
-- [NPM registry authentication]({% link pages/maintainer/npm_registry_auth.md %})
+- [npm registry authentication]({% link pages/maintainer/npm_registry_auth.md %})
 - [.npmrc-publish]({% link pages/configs/npmrc-publish.md %}) config file

--- a/pages/configs/pnpmfile_js.md
+++ b/pages/configs/pnpmfile_js.md
@@ -12,16 +12,16 @@ generates for **pnpmfile.js**:
 "use strict";
 
 /**
- * When using the PNPM package manager, you can use pnpmfile.js to workaround
+ * When using the pnpm package manager, you can use pnpmfile.js to workaround
  * dependencies that have mistakes in their package.json file.  (This feature is
  * functionally similar to Yarn's "resolutions".)
  *
- * For details, see the PNPM documentation:
+ * For details, see the pnpm documentation:
  * https://pnpm.js.org/docs/en/hooks.html
  *
  * IMPORTANT: SINCE THIS FILE CONTAINS EXECUTABLE CODE, MODIFYING IT IS LIKELY TO INVALIDATE
  * ANY CACHED DEPENDENCY ANALYSIS.  After any modification to pnpmfile.js, it's recommended to run
- * "rush update --full" so that PNPM will recalculate all version selections.
+ * "rush update --full" so that pnpm will recalculate all version selections.
  */
 module.exports = {
   hooks: {

--- a/pages/configs/rush_json.md
+++ b/pages/configs/rush_json.md
@@ -82,7 +82,7 @@ generates for **rush.json** (in the repo root folder):
      * option for PNPM.  Possible values are "fast" and "fewer-dependencies".  PNPM's default is "fast", but this may
      * be incompatible with certain packages, for example the "@types" packages from DefinitelyTyped.  Rush's default
      * is "fewer-dependencies", which causes PNPM to avoid installing a newer version if an already installed version
-     * can be reused; this is more similar to NPM's algorithm.
+     * can be reused; this is more similar to npm's algorithm.
      *
      * After modifying this field, it's recommended to run "rush update --full" so that the package manager
      * will recalculate all version selections.
@@ -230,7 +230,7 @@ generates for **rush.json** (in the repo root folder):
   //   ],
   //
   //   /**
-  //    * A list of NPM package scopes that will be excluded from review.
+  //    * A list of npm package scopes that will be excluded from review.
   //    * We recommend to exclude TypeScript typings (the "@types" scope), because
   //    * if the underlying package was already approved, this would imply that the typings
   //    * are also approved.
@@ -402,7 +402,7 @@ generates for **rush.json** (in the repo root folder):
   "projects": [
     // {
     //   /**
-    //    * The NPM package name of the project (must match package.json)
+    //    * The npm package name of the project (must match package.json)
     //    */
     //   "packageName": "my-app",
     //

--- a/pages/configs/rush_json.md
+++ b/pages/configs/rush_json.md
@@ -43,17 +43,17 @@ generates for **rush.json** (in the repo root folder):
   // "yarnVersion": "1.9.4",
 
   /**
-   * Options that are only used when the PNPM package manager is selected
+   * Options that are only used when the pnpm package manager is selected
    */
   "pnpmOptions": {
     /**
-     * Specifies the location of the PNPM store.  There are two possible values:
+     * Specifies the location of the pnpm store.  There are two possible values:
      *
      * - "local" - use the "pnpm-store" folder in the current configured temp folder:
      *   "common/temp/pnpm-store" by default.
-     * - "global" - use PNPM's global store, which has the benefit of being shared
+     * - "global" - use pnpm's global store, which has the benefit of being shared
      *    across multiple repo folders, but the disadvantage of less isolation for builds
-     *    (e.g. bugs or incompatibilities when two repos use different releases of PNPM)
+     *    (e.g. bugs or incompatibilities when two repos use different releases of pnpm)
      *
      * RUSH_PNPM_STORE_PATH will override the directory that will be used as the store
      *
@@ -64,7 +64,7 @@ generates for **rush.json** (in the repo root folder):
     // "pnpmStore": "local",
 
     /**
-     * If true, then Rush will add the "--strict-peer-dependencies" option when invoking PNPM.
+     * If true, then Rush will add the "--strict-peer-dependencies" option when invoking pnpm.
      * This causes "rush install" to fail if there are unsatisfied peer dependencies, which is
      * an invalid state that can cause build failures or incompatible dependency versions.
      * (For historical reasons, JavaScript package managers generally do not treat this invalid
@@ -78,10 +78,10 @@ generates for **rush.json** (in the repo root folder):
     /**
      * Configures the strategy used to select versions during installation.
      *
-     * This feature requires PNPM version 3.1 or newer.  It corresponds to the "--resolution-strategy" command-line
-     * option for PNPM.  Possible values are "fast" and "fewer-dependencies".  PNPM's default is "fast", but this may
+     * This feature requires pnpm version 3.1 or newer.  It corresponds to the "--resolution-strategy" command-line
+     * option for pnpm.  Possible values are "fast" and "fewer-dependencies".  pnpm's default is "fast", but this may
      * be incompatible with certain packages, for example the "@types" packages from DefinitelyTyped.  Rush's default
-     * is "fewer-dependencies", which causes PNPM to avoid installing a newer version if an already installed version
+     * is "fewer-dependencies", which causes pnpm to avoid installing a newer version if an already installed version
      * can be reused; this is more similar to npm's algorithm.
      *
      * After modifying this field, it's recommended to run "rush update --full" so that the package manager
@@ -91,14 +91,14 @@ generates for **rush.json** (in the repo root folder):
 
     /**
      * If true, then `rush install` will report an error if manual modifications
-     * were made to the PNPM shrinkwrap file without running "rush update" afterwards.
+     * were made to the pnpm shrinkwrap file without running "rush update" afterwards.
      *
      * This feature protects against accidental inconsistencies that may be introduced
-     * if the PNPM shrinkwrap file ("pnpm-lock.yaml") is manually edited.  When this
+     * if the pnpm shrinkwrap file ("pnpm-lock.yaml") is manually edited.  When this
      * feature is enabled, "rush update" will append a hash to the file as a YAML comment,
      * and then "rush update" and "rush install" will validate the hash.  Note that this does not prohibit
      * manual modifications, but merely requires "rush update" be run
-     * afterwards, ensuring that PNPM can report or repair any potential inconsistencies.
+     * afterwards, ensuring that pnpm can report or repair any potential inconsistencies.
      *
      * To temporarily disable this validation when invoking "rush install", use the
      * "--bypass-policy" command-line parameter.
@@ -108,10 +108,10 @@ generates for **rush.json** (in the repo root folder):
     // "preventManualShrinkwrapChanges": true,
 
     /**
-     * If true, then `rush install` will use the PNPM workspaces feature to perform the
+     * If true, then `rush install` will use the pnpm workspaces feature to perform the
      * install.
      *
-     * This feature uses PNPM to perform the entire monorepo install. When using workspaces, Rush will
+     * This feature uses pnpm to perform the entire monorepo install. When using workspaces, Rush will
      * generate a "pnpm-workspace.yaml" file referencing all local projects to install. Rush will
      * also generate a "pnpmfile.js" which is used to provide preferred versions support. When install
      * is run, this pnpmfile will be used to replace dependency version ranges with a smaller subset

--- a/pages/configs/version-policies_json.md
+++ b/pages/configs/version-policies_json.md
@@ -27,7 +27,7 @@ generates for **version-policies.json**:
   //    * The "lockStepVersion" mode specifies that the projects will use "lock-step versioning".  This
   //    * strategy is appropriate for a set of packages that act as selectable components of a
   //    * unified product.  The entire set of packages are always published together, and always share
-  //    * the same NPM version number.  When the packages depend on other packages in the set, the
+  //    * the same npm version number.  When the packages depend on other packages in the set, the
   //    * SemVer range is usually restricted to a single version.
   //    */
   //   "definitionName": "lockStepVersion",
@@ -70,7 +70,7 @@ generates for **version-policies.json**:
   //    * (Required) Indicates the kind of version policy being defined ("lockStepVersion" or "individualVersion").
   //    *
   //    * The "individualVersion" mode specifies that the projects will use "individual versioning".
-  //    * This is the typical NPM model where each package has an independent version number
+  //    * This is the typical npm model where each package has an independent version number
   //    * and CHANGELOG.md file.  Although a single CI definition is responsible for publishing the
   //    * packages, they otherwise don't have any special relationship.  The version bumping will
   //    * depend on how developers answer the "rush change" questions for each package that

--- a/pages/developer/everyday_commands.md
+++ b/pages/developer/everyday_commands.md
@@ -46,7 +46,7 @@ After editing a **package.json** file, you can run `rush check` to see if multip
 
 ## rush change
 
-If you work on libraries that get published as NPM packages, your repo probably requires you to include change log entries as part of your PR.  You will know because your PR build will fail on the `rush change --verify` step.
+If you work on libraries that get published as npm packages, your repo probably requires you to include change log entries as part of your PR.  You will know because your PR build will fail on the `rush change --verify` step.
 
 To write change logs, first commit any pending work to Git.  Then type `rush change` from anywhere under your repo working folder.  This command will examine your Git history to determine which project folders have diffs.  Based on that, it will prompt you to write a change log entry for each one.  Each change log entry gets stored in a separate file under **common/changes**.  You should add and commit these files to Git.
 
@@ -65,7 +65,7 @@ Combining everything, a typical daily incantation might look like this:
 # Pull the latest changes from Git
 $ git pull
 
-# Install NPM packages as needed
+# Install npm packages as needed
 $ rush update
 
 # Do a clean rebuild of everything

--- a/pages/developer/modifying_package_json.md
+++ b/pages/developer/modifying_package_json.md
@@ -30,7 +30,7 @@ The `rush add` command can also be used to update the version of an existing dep
 # Or if you want the version specifier "^1.2.3":
 ~/my-repo/apps/my-app$ rush add --package example-lib@1.2.3 --caret
 
-# A more advanced example, where we query the NPM registry to find latest version that is
+# A more advanced example, where we query the npm registry to find latest version that is
 # compatible with the SemVer specifier "^1.2.0" and then add it as a tilde dependency
 # such as "~1.5.3".
 #
@@ -49,12 +49,12 @@ The [command-line help]({% link pages/commands/rush_add.md %}) for `rush add` de
 
 > **Tip: A cool VS Code feature**
 >
-> By the way, if you use Visual Studio Code as your editor, another option is to simply edit the **package.json** file directly. If you start typing `"example-lib":`, VS Code will automatically query the NPM registry and show autocomplete suggestions for the latest published version.  For simple additions, this can be even quicker than `rush add`.
+> By the way, if you use Visual Studio Code as your editor, another option is to simply edit the **package.json** file directly. If you start typing `"example-lib":`, VS Code will automatically query the npm registry and show autocomplete suggestions for the latest published version.  For simple additions, this can be even quicker than `rush add`.
 >
 > If you modify **package.json** manually, don't forget to run `rush update` afterwards.
 
 
-## Upgrading to newer versions of your NPM packages
+## Upgrading to newer versions of your npm packages
 
 The `rush update --full` can install newer versions that satisfy your existing **package.json** files; however, if you want to upgrade the **package.json** files to specify newer version ranges, today Rush does not yet provide a command for doing that in bulk.
 

--- a/pages/developer/modifying_package_json.md
+++ b/pages/developer/modifying_package_json.md
@@ -60,6 +60,6 @@ The `rush update --full` can install newer versions that satisfy your existing *
 
 The [npm-check-updates](https://www.npmjs.com/package/npm-check-updates) tool will work to upgrade individual projects in a Rush repo, as long as you remember to run `rush update` afterwards (instead of `npm install`).
 
-*NOTE: Support for PNPM workspaces is [coming very soon](https://github.com/microsoft/rushstack/pull/1938); with this feature enabled, the [pnpm update](https://pnpm.js.org/en/cli/update) command can be used for bulk upgrades.*
+*NOTE: Support for pnpm workspaces is [coming very soon](https://github.com/microsoft/rushstack/pull/1938); with this feature enabled, the [pnpm update](https://pnpm.js.org/en/cli/update) command can be used for bulk upgrades.*
 
 #### Next up: [Other helpful commands]({% link pages/developer/other_commands.md %})

--- a/pages/developer/new_developer.md
+++ b/pages/developer/new_developer.md
@@ -14,7 +14,7 @@ You also need to install the Rush tool itself.  It's pretty easy.  From your she
 $ npm install -g @microsoft/rush
 ```
 
-*NOTE: If this command fails because your user account does not have permissions to access NPM's global folder, you may need to [fix your NPM configuration](https://docs.npmjs.com/getting-started/fixing-npm-permissions).*
+*NOTE: If this command fails because your user account does not have permissions to access npm's global folder, you may need to [fix your npm configuration](https://docs.npmjs.com/getting-started/fixing-npm-permissions).*
 
 To see Rush's command line help, you can type:
 
@@ -41,7 +41,7 @@ Afterwards you can run `rush update` to recreate the symlinks.  (There is a stan
 
 #### 2. If you suspect your install is corrupted...
 
-Rush's package management commands are "incremental", which means they save time by skipping steps that appear to be unnecessary.  Since Rush runs in automated build environments, we have many safeguards to ensure these checks are accurate.  However when debugging or tinkering with packages on your local machine, sometimes your NPM "node_modules" folder can get into a bad state, causing strange errors.
+Rush's package management commands are "incremental", which means they save time by skipping steps that appear to be unnecessary.  Since Rush runs in automated build environments, we have many safeguards to ensure these checks are accurate.  However when debugging or tinkering with packages on your local machine, sometimes your npm "node_modules" folder can get into a bad state, causing strange errors.
 
 If you suspect your install is corrupted, try running `rush update --purge`.  This will force a full reinstall of your packages, and usually get you back into a good state.
 

--- a/pages/developer/other_commands.md
+++ b/pages/developer/other_commands.md
@@ -28,7 +28,7 @@ The full set of project selection parameters are described in the article [Selec
 
 ## A faster way to install
 
-If your repo is using PNPM with the new `useWorkspaces=true` mode enabled in your [rush.json]({% link pages/configs/rush_json.md %}) file, you can use a feature called "filtered installs".  This feature reduces installation times by only installing the subset of npm packages required to build a specific project.
+If your repo is using pnpm with the new `useWorkspaces=true` mode enabled in your [rush.json]({% link pages/configs/rush_json.md %}) file, you can use a feature called "filtered installs".  This feature reduces installation times by only installing the subset of npm packages required to build a specific project.
 
 For example:
 ```sh

--- a/pages/developer/other_commands.md
+++ b/pages/developer/other_commands.md
@@ -28,11 +28,11 @@ The full set of project selection parameters are described in the article [Selec
 
 ## A faster way to install
 
-If your repo is using PNPM with the new `useWorkspaces=true` mode enabled in your [rush.json]({% link pages/configs/rush_json.md %}) file, you can use a feature called "filtered installs".  This feature reduces installation times by only installing the subset of NPM packages required to build a specific project.
+If your repo is using PNPM with the new `useWorkspaces=true` mode enabled in your [rush.json]({% link pages/configs/rush_json.md %}) file, you can use a feature called "filtered installs".  This feature reduces installation times by only installing the subset of npm packages required to build a specific project.
 
 For example:
 ```sh
-# Only install the NPM packages needed to build "my-project" and the other
+# Only install the npm packages needed to build "my-project" and the other
 # Rush projects that it depends on:
 $ rush install --to my-project
 
@@ -55,7 +55,7 @@ After working with Rush, maybe you want to get back to a clean state, e.g. so yo
 $ rush unlink
 
 # Remove all the temporary files created by Rush, including deleting all
-# the NPM packages that were installed in your common folder:
+# the npm packages that were installed in your common folder:
 $ rush purge
 ```
 

--- a/pages/developer/selecting_subsets.md
+++ b/pages/developer/selecting_subsets.md
@@ -13,7 +13,7 @@ Suppose we're working with the following collection of Rush projects:
 
 <img src="/images/docs/selection-intro.svg" alt="a sample monorepo" style="height: 150px;" />
 
-In the above illustration, the circles represent local projects, not external NPM dependencies.
+In the above illustration, the circles represent local projects, not external npm dependencies.
 The arrow from `D` to `C` indicates that `D` depends on `C`; this means that `C` must be built before
 `D` can be built.  We'll use the `rush build` command in the examples given below, but these same parameters
 work for any bulk command.

--- a/pages/help/faq.md
+++ b/pages/help/faq.md
@@ -13,7 +13,7 @@ Open a [GitHub issue](https://github.com/microsoft/rushstack/issues) for the **r
 
 ### With many projects in one repo, will "npm install" take too long?
 
-You might be thinking: "Hmmm.. if my current install takes 3 minutes, and you want me to put 20 projects in one repo, won't that multiply my NPM install time to 60 minutes!?"  Nope.  Rush centralizes your dependencies in a "common" folder and runs "npm install" exactly once, with essentially the same install time as your original monolithic application.
+You might be thinking: "Hmmm.. if my current install takes 3 minutes, and you want me to put 20 projects in one repo, won't that multiply my npm install time to 60 minutes!?"  Nope.  Rush centralizes your dependencies in a "common" folder and runs "npm install" exactly once, with essentially the same install time as your original monolithic application.
 
 ### Will Rush make my tooling nonstandard?
 
@@ -44,16 +44,16 @@ $ rush
 Rush Multi-Package Build Tool 2.5.0 - http://aka.ms/rush
 ```
 
-NPM seems to say that it is installing version 3.0.1, but when we execute the command, it shows Rush version 2.5.0.  What's going on here?!
+npm seems to say that it is installing version 3.0.1, but when we execute the command, it shows Rush version 2.5.0.  What's going on here?!
 
-The problem is that when you type commands like "gulp" or "rush", they are found in your system PATH, which can be pointing to folders from previous installs of NodeJS or NPM.
+The problem is that when you type commands like "gulp" or "rush", they are found in your system PATH, which can be pointing to folders from previous installs of NodeJS or npm.
 
 The fix:
-1. Run `npm ls -g --depth 0` to figure out where your NPM packages are being installed.
+1. Run `npm ls -g --depth 0` to figure out where your npm packages are being installed.
 2. Run the `set` command, and examine your PATH environment variable.
-3. Make sure that no other NPM or NodeJS folders appear in your PATH before the folder from #1
-4. Delete any obsolete folders from your PATH, e.g. from an old install of NPM, NodeJS, nodist, nvm-windows, etc.
-5. If you previously used one of these alternative engines, most likely you have a bunch of deadwood NPM packages left behind on your disk somewhere.  It's a good idea to track them down and delete them.
+3. Make sure that no other npm or NodeJS folders appear in your PATH before the folder from #1
+4. Delete any obsolete folders from your PATH, e.g. from an old install of npm, NodeJS, nodist, nvm-windows, etc.
+5. If you previously used one of these alternative engines, most likely you have a bunch of deadwood npm packages left behind on your disk somewhere.  It's a good idea to track them down and delete them.
 
 Some places to look:
 ```
@@ -65,9 +65,9 @@ C:\Program Files (x86)\nodist
 
 ### The "npm install" step is reporting network errors -- what to do?
 
-If you install packages from a custom NPM registry (e.g. a private server for your company or a caching proxy), then your project maintainer will instruct you to add special configuration settings in your .npmrc file.  If these settings are incorrect, "npm install" may report confusing errors that seem to indicate a network failure.  It's important to understand that the NPM tool looks for ".npmrc" files multiple locations (and ignores other locations).
+If you install packages from a custom npm registry (e.g. a private server for your company or a caching proxy), then your project maintainer will instruct you to add special configuration settings in your .npmrc file.  If these settings are incorrect, "npm install" may report confusing errors that seem to indicate a network failure.  It's important to understand that the npm tool looks for ".npmrc" files multiple locations (and ignores other locations).
 
-Without Rush, NPM looks for "**.npmrc**" in these two places, *and merges their contents*:
+Without Rush, npm looks for "**.npmrc**" in these two places, *and merges their contents*:
 - in the same folder as your package.json (useful for storing project-specific settings in Git)
 - in your user home directory (your authentication token goes here)
 
@@ -104,8 +104,8 @@ caching issue):
 
 ### How to clean up Rush's installation to avoid interfering with other tools?
 
-Generally it's recommended to perform all monorepo management using Rush.  The symlinks that Rush creates under the project `node_modules` folders may confuse other tools such as NPM or Yarn, causing them to malfunction because they expect a different installation model.  Sometimes this is unavoidable, however.  For example, when migrating an existing repo to use Rush however, the CI system may need to reuse an existing working folder to build different branches that use different installation models.  To prevent interference, your CI job will first need to invoke a command that deletes the old files from the previous installation model.
+Generally it's recommended to perform all monorepo management using Rush.  The symlinks that Rush creates under the project `node_modules` folders may confuse other tools such as npm or Yarn, causing them to malfunction because they expect a different installation model.  Sometimes this is unavoidable, however.  For example, when migrating an existing repo to use Rush however, the CI system may need to reuse an existing working folder to build different branches that use different installation models.  To prevent interference, your CI job will first need to invoke a command that deletes the old files from the previous installation model.
 
-For Yarn or NPM, a command like `git clean -dfx` is generally sufficient. (THIS DELETES FILES -- [read the manual](https://git-scm.com/docs/git-clean) before invoking!)
+For Yarn or npm, a command like `git clean -dfx` is generally sufficient. (THIS DELETES FILES -- [read the manual](https://git-scm.com/docs/git-clean) before invoking!)
 
 For cleaning up a Rush installation, `git clean` is NOT recommended because it does not handle symlinks reliably.  Instead, use the [rush purge]({% link pages/commands/rush_purge.md %}) command to delete the `node_modules` folders created by Rush.

--- a/pages/intro/get_started.md
+++ b/pages/intro/get_started.md
@@ -25,7 +25,7 @@ $ rush -h
 $ git clone https://github.com/microsoft/rushstack
 $ cd rushstack
 
-# Install the NPM packages:
+# Install the npm packages:
 # (If you don't have a GitHub email configured, add the "--bypass-policy" option.)
 $ rush update
 

--- a/pages/intro/welcome.md
+++ b/pages/intro/welcome.md
@@ -6,11 +6,11 @@ navigation_source: docs_nav
 
 ![My helpful screenshot]({{ "/images/rush.svg" | absolute_url }}){:style="width: 12rem"}
 
-**Rush** makes life easier for JavaScript developers who build and publish many NPM packages at once.  If you're looking to consolidate all your projects into a single repo, you came to the right place!  Rush is a fast, professional solution for managing this scenario.  It gives you:
+**Rush** makes life easier for JavaScript developers who build and publish many npm packages at once.  If you're looking to consolidate all your projects into a single repo, you came to the right place!  Rush is a fast, professional solution for managing this scenario.  It gives you:
 
-- **A single NPM install:** In one step, Rush installs all the dependencies for all your projects into a common folder.  This is not just a "package.json" file at the root of your repo (which might set you up to accidentally `require()` a sibling's dependencies).  Instead, Rush uses symlinks to reconstruct an accurate "node_modules" folder for each project, without any of the limitations or glitches that seem to plague other approaches.
+- **A single npm install:** In one step, Rush installs all the dependencies for all your projects into a common folder.  This is not just a "package.json" file at the root of your repo (which might set you up to accidentally `require()` a sibling's dependencies).  Instead, Rush uses symlinks to reconstruct an accurate "node_modules" folder for each project, without any of the limitations or glitches that seem to plague other approaches.
 
-  ⏵ **This algorithm supports the [PNPM, NPM, and Yarn]({% link pages/maintainer/package_managers.md %}) package managers.**
+  ⏵ **This algorithm supports the [PNPM, npm, and Yarn]({% link pages/maintainer/package_managers.md %}) package managers.**
 
 - **Automatic local linking:** Inside a Rush repo, all your projects are automatically symlinked to each other. When you make a change, you can see the downstream effects without publishing anything, and without any `npm link` headaches.  If you don't want certain projects to get linked, that's supported, too.
 
@@ -26,7 +26,7 @@ navigation_source: docs_nav
 
 - **Enterprise policies:** Want to review new libraries before developers add them to package.json, but avoid hassling people about already approved cases?  Want to enforce that all your projects depend on the same library version numbers?  Are unprofessional personal e-mail addresses accidentally showing up in your company's Git history?  Rush can help maintain a consistent ecosystem when you've got many developers and many projects in the mix.
 
-- **Lots more!** Rush was created by the platform team for [Microsoft SharePoint](http://aka.ms/spfx).  We build hundreds of production NPM packages every day, from internal and public Git repositories, for third party SDKs and live services with millions of users.  If there's an important package management problem that needs solvin', it's likely to end up as a feature for Rush.
+- **Lots more!** Rush was created by the platform team for [Microsoft SharePoint](http://aka.ms/spfx).  We build hundreds of production npm packages every day, from internal and public Git repositories, for third party SDKs and live services with millions of users.  If there's an important package management problem that needs solvin', it's likely to end up as a feature for Rush.
 
 
 #### Next up: [Getting started with Rush]({% link pages/intro/get_started.md %})

--- a/pages/intro/welcome.md
+++ b/pages/intro/welcome.md
@@ -10,7 +10,7 @@ navigation_source: docs_nav
 
 - **A single npm install:** In one step, Rush installs all the dependencies for all your projects into a common folder.  This is not just a "package.json" file at the root of your repo (which might set you up to accidentally `require()` a sibling's dependencies).  Instead, Rush uses symlinks to reconstruct an accurate "node_modules" folder for each project, without any of the limitations or glitches that seem to plague other approaches.
 
-  ⏵ **This algorithm supports the [PNPM, npm, and Yarn]({% link pages/maintainer/package_managers.md %}) package managers.**
+  ⏵ **This algorithm supports the [pnpm, npm, and Yarn]({% link pages/maintainer/package_managers.md %}) package managers.**
 
 - **Automatic local linking:** Inside a Rush repo, all your projects are automatically symlinked to each other. When you make a change, you can see the downstream effects without publishing anything, and without any `npm link` headaches.  If you don't want certain projects to get linked, that's supported, too.
 

--- a/pages/intro/why_mono.md
+++ b/pages/intro/why_mono.md
@@ -4,13 +4,13 @@ title: Why one big repo⁈
 navigation_source: docs_nav
 ---
 
-_Open source NPM packages seem to be developed in lots of small GitHub repos.  Shouldn't I do that?_
+_Open source npm packages seem to be developed in lots of small GitHub repos.  Shouldn't I do that?_
 
 Sure, if you're building isolated components, and it's not too important how they fit together.  But business software doesn't seem to work that way.  It's more like this:
 
 Most people start out by building a single web application, not a bunch of libraries.  After your application ships, it keeps growing in size.  Then one day you need to share some code with a different project, and you realize you've got a big rat's nest.  Time to refactor!
 
-Clearly you must split this thing up into manageable components.  NPM packages are the way to do that in JavaScript.  Looking around, the convention seems to be "**one GitHub repo for each NPM package.**"  During a heroic week or two, you create 10 Git repos, split up your code, and give it a try...
+Clearly you must split this thing up into manageable components.  npm packages are the way to do that in JavaScript.  Looking around, the convention seems to be "**one GitHub repo for each npm package.**"  During a heroic week or two, you create 10 Git repos, split up your code, and give it a try...
 
 ...but working with 10 Git repos turns out to be a big pain!  There are just so many headaches:
 
@@ -20,7 +20,7 @@ Clearly you must split this thing up into manageable components.  NPM packages a
 
 - **Downstream victims**: When Bob publishes a change to **lib3**, it can take a while before all downstream projects get upgraded to use it.  If there's a regression, it might be a week before Alice tries to run "npm update" in **lib1** and discovers the problem.  By then, maybe Bob has left for his backpacking trip across Europe.  Why should Alice shoulder the burden of fixing someone else's regression?  Seems like every time she upgrades, something is broken!
 
-- **Linking madness**: The workaround is to use [npm link](https://docs.npmjs.com/cli/link) to symlink your **application** directly to **lib3** for testing.  But NPM creates symlinks via a global folder, which causes trouble if you need to work with multiple branches of **lib3** on the same laptop.  And with 10+ libraries, it's hard to remember what is symlinked to what.
+- **Linking madness**: The workaround is to use [npm link](https://docs.npmjs.com/cli/link) to symlink your **application** directly to **lib3** for testing.  But npm creates symlinks via a global folder, which causes trouble if you need to work with multiple branches of **lib3** on the same laptop.  And with 10+ libraries, it's hard to remember what is symlinked to what.
 
 The **"one repo per package"** model makes sense for isolated projects that are maintained by uncoordinated strangers.  (Also, most of those libraries get updated fairly infrequently, which makes the problem easier.)  Whereas in our example, everyone works at the same company, and the "libraries" act more like components of an integrated architecture.  Code gets churned a lot, and a change in one place can easily break another part of the system.  Building multiple projects together lets you run all the unit tests for every change, which moves responsibility for fixes where it belongs:  To the person who originally introduced the change.
 

--- a/pages/maintainer/add_to_repo.md
+++ b/pages/maintainer/add_to_repo.md
@@ -88,7 +88,7 @@ any subfolder of the repo folder that contains rush.json:
 ```
 Since this is the first project for the repo, you'll notice that `rush update` creates several new files:
 
-- **common/config/rush/shrinkwrap.yaml**: The common shrinkwrap file (here we're assuming PNPM package manager)
+- **common/config/rush/shrinkwrap.yaml**: The common shrinkwrap file (here we're assuming pnpm package manager)
 - **common/scripts/install-run-rush.js**: Used by CI jobs to bootstrap the Rush tool in a reliable way
 - **common/scripts/install-run.js**: Used by CI jobs to bootstrap arbitrary tools in a reliable way
 
@@ -140,7 +140,7 @@ Rush provides a lot of command-line switches for building projects.  See [rush b
 
 > **Phantom dependency errors**
 >
-> Rush and PNPM use symlinks to prevent projects from importing [phantom dependencies]({% link pages/advanced/phantom_deps.md %}).
+> Rush and pnpm use symlinks to prevent projects from importing [phantom dependencies]({% link pages/advanced/phantom_deps.md %}).
 > If an npm dependency is not declared in your **package.json** file, a runtime error may occur if your project tries to
 > import it.  These phantom dependency errors are one of the most common issues when migrating an existing project into
 > a Rush monorepo.  Generally the fix is simply to add the missing dependency to your **package.json** file.

--- a/pages/maintainer/add_to_repo.md
+++ b/pages/maintainer/add_to_repo.md
@@ -141,7 +141,7 @@ Rush provides a lot of command-line switches for building projects.  See [rush b
 > **Phantom dependency errors**
 >
 > Rush and PNPM use symlinks to prevent projects from importing [phantom dependencies]({% link pages/advanced/phantom_deps.md %}).
-> If an NPM dependency is not declared in your **package.json** file, a runtime error may occur if your project tries to
+> If an npm dependency is not declared in your **package.json** file, a runtime error may occur if your project tries to
 > import it.  These phantom dependency errors are one of the most common issues when migrating an existing project into
 > a Rush monorepo.  Generally the fix is simply to add the missing dependency to your **package.json** file.
 >

--- a/pages/maintainer/build_cache.md
+++ b/pages/maintainer/build_cache.md
@@ -12,7 +12,7 @@ the build output is not saved anywhere, so generally a full rebuild is still req
 Rush's experimental new **build cache** improves on this by creating a tar archive of each project's build outputs.
 The archive is cached so that later, if `rush build` can find a match in the cache, it can extract the archive
 instead of building that project.  This can provide dramatic speedups, for example reducing a 30 minute build time
-to 30 seconds.  The cache key is a hash of the source files and NPM dependencies, following the
+to 30 seconds.  The cache key is a hash of the source files and npm dependencies, following the
 [same basic rules]({% link pages/advanced/incremental_builds.md %}) as the incremental analyzer.
 
 The build cache archives are stored in two places:

--- a/pages/maintainer/deploying.md
+++ b/pages/maintainer/deploying.md
@@ -9,8 +9,8 @@ For example, let's say the Node.js service is a local Rush project called `app1`
 organized as follows:
 
 - **apps/app1**:
-  - depends on `ext-lib7` (from NPM) and `lib3` (a local project)
-  - dev dependencies on `ext-tool8` (from NPM) and `tool6` (a local project)
+  - depends on `ext-lib7` (from npm) and `lib3` (a local project)
+  - dev dependencies on `ext-tool8` (from npm) and `tool6` (a local project)
 - **apps/app2**: depends on `lib3` and `lib4`
 - **libraries/lib3**: depends on `lib5`
 - **libraries/lib4**: no dependencies
@@ -18,7 +18,7 @@ organized as follows:
 - **tools/tool6**: no dependencies
 
 One solution might be to run `rush install` and `rush build`, and then copy the entire monorepo to the server.
-However, this could potentially include many extraneous files and NPM packages. Instead we would like to copy
+However, this could potentially include many extraneous files and npm packages. Instead we would like to copy
 only `app1` and its regular dependencies (`ext-lib7`, `lib3`, `lib5`). We do not want to include dev dependencies such
 as `ext-tool8`.
 

--- a/pages/maintainer/deploying.md
+++ b/pages/maintainer/deploying.md
@@ -81,7 +81,7 @@ is to upload the **common/deploy** subtree to your server machine.
 ## Handling links
 
 The **common/deploy** subtree will have symbolic links created by `rush install`. For example, if you are using the
-PNPM package manager, then **common/deploy/apps/app1/node_modules/ext-lib7** may be a symlink to a folder under the
+pnpm package manager, then **common/deploy/apps/app1/node_modules/ext-lib7** may be a symlink to a folder under the
 **common/deploy/common/temp/node_modules/.pnpm/...** path. Correctly replicating these links can be problematic for
 upload tools such as `tar` or `ftp`.
 

--- a/pages/maintainer/enabling_ci_builds.md
+++ b/pages/maintainer/enabling_ci_builds.md
@@ -17,7 +17,7 @@ $ git fetch origin master:refs/remotes/origin/master -a
 # a nonzero exit code.
 $ rush change -v
 
-# Install NPM packages in the common folder, but don't automatically do "rush link"
+# Install npm packages in the common folder, but don't automatically do "rush link"
 $ rush install --no-link
 
 # Run "rush link" explicitly, so your CI system can measure it as a separate step
@@ -64,7 +64,7 @@ Below we'll show how to incorporate this into a Travis build definition.
 ## install-run.js for other commands
 
 By the way, Rush provides a second script **install-run.js** that allows you to use this same
-technology with arbitrary NPM packages.  For example, here's a command that prints a QR code
+technology with arbitrary npm packages.  For example, here's a command that prints a QR code
 for the Rush web site:  :-)
 
 ```

--- a/pages/maintainer/enabling_prettier.md
+++ b/pages/maintainer/enabling_prettier.md
@@ -201,7 +201,7 @@ For this situation, Rush's "autoinstaller" feature provides a convenient alterna
 
 5.  After saving these changes, let's test our custom command by running `rush prettier`.  The first time you should
     see Rush automatically performing a number of steps:  (1) install the correct version of the Rush engine,
-    (2) install the correct version of the PNPM package manager, (3) installing **rush-prettier/package.json**
+    (2) install the correct version of the pnpm package manager, (3) installing **rush-prettier/package.json**
     and its dependencies, (4) invoking `pretty-quick --staged`.  However the second time you invoke it, the first
     3 steps are up to date, so step (4) runs without any delay.  Nice!
 

--- a/pages/maintainer/npm_registry_auth.md
+++ b/pages/maintainer/npm_registry_auth.md
@@ -1,25 +1,25 @@
 ---
 layout: page
-title: NPM registry authentication
+title: npm registry authentication
 navigation_source: docs_nav
 ---
 
-A **private NPM registry** enables your monorepo to publish NPM packages for internal usage.  It works the same as
+A **private npm registry** enables your monorepo to publish npm packages for internal usage.  It works the same as
 the public [https://www.npmjs.com/](https://www.npmjs.com/) registry, except that accessing the private registry
 requires authorization.  Each user will need to obtain an access token that typically gets stored in the
 [~/.npmrc file](https://docs.npmjs.com/cli/v6/configuring-npm/npmrc)
 on their computer.
 
-Most large monorepos eventually require a private NPM registry.  It's useful for:
+Most large monorepos eventually require a private npm registry.  It's useful for:
 
 - sharing code privately between teams
 - proxying access to the public registry, to improve reliability, audit package usage, and apply security screening
 - speeding up CI operations by installing prebuilt tooling packages, instead of performing `rush install && rush build`
   before a tool can be invoked
-- testing installation behaviors before publishing a package to public NPM registry
+- testing installation behaviors before publishing a package to public npm registry
 - publishing wrappers or temporary forks of third-party packages<br/>
   (Compared to [GitHub URL dependencies](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#github-urls),
-  NPM packages give you proper SemVer versioning and better caching semantics.)
+  npm packages give you proper SemVer versioning and better caching semantics.)
 
 Some popular providers are:
 
@@ -28,7 +28,7 @@ Some popular providers are:
 - [GitHub Packages](https://github.com/features/packages)
 - [GitLab Package Registry](https://docs.gitlab.com/ee/user/packages/npm_registry/)
 - [JFrog Artifactory](https://jfrog.com/artifactory/)
-- [NPM private packages](https://docs.npmjs.com/about-private-packages)
+- [npm private packages](https://docs.npmjs.com/about-private-packages)
 
 And for testing purposes, [Verdaccio](https://verdaccio.org/) is a lightweight Node.js server that can run
 on `http://localhost` and implements a complete private registry with proxy capabilities.
@@ -41,14 +41,14 @@ The mappings for your private registry are specified in
 
 Below is an example configuration that installs company packages from the private
 registry, but gets all other packages from the public registry.  The company packages are
-identified by their `@example` NPM scope.
+identified by their `@example` npm scope.
 
 **common/config/rush/.npmrc**
 ```shell
-# Map your company's NPM scope ("@example") to the private registry URL:
+# Map your company's npm scope ("@example") to the private registry URL:
 @example:registry=https://my-registry.example.com/npm-private/
 
-# Otherwise, all other packages come from the public NPM registry:
+# Otherwise, all other packages come from the public npm registry:
 registry=https://registry.npmjs.org/
 always-auth=false
 
@@ -63,7 +63,7 @@ always-auth=false
 ```
 
 More commonly, your private registry will act as a **caching proxy** so that it can provide
-packages from the public NPM registry as well.  In this case, NPM scopes don't need to be mapped.
+packages from the public npm registry as well.  In this case, npm scopes don't need to be mapped.
 Your setup might look like this:
 
 **common/config/rush/.npmrc**
@@ -94,11 +94,11 @@ any existing contents of that file.
 
 A sample `rush setup` interaction looks like this:
 ```
-NPM credentials are missing or expired
+npm credentials are missing or expired
 
 ==> Fix this problem now? (y/N) Yes
 
-This monorepo consumes packages from an Artifactory private NPM registry.
+This monorepo consumes packages from an Artifactory private npm registry.
 
 ==> Do you already have an Artifactory user account? (y/n) Yes
 
@@ -115,7 +115,7 @@ previously.
 
 ==> What is your Artifactory API key? ***************
 
-Fetching an NPM token from the Artifactory service...
+Fetching an npm token from the Artifactory service...
 
 Adding Artifactory token to: /home/example-user/.npmrc
 ```

--- a/pages/maintainer/package_managers.md
+++ b/pages/maintainer/package_managers.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: npm vs PNPM vs Yarn
+title: npm vs pnpm vs Yarn
 navigation_source: docs_nav
 ---
 
@@ -10,7 +10,7 @@ Before you can start installing a JavaScript library, you need to choose which p
 
 - [Yarn](https://yarnpkg.com/en/): a complete rewrite of the npm tool that preserves the same installation model, but promises faster installations, better reliability, and some cool new features (e.g. Yarn workspaces) that facilitate large scale development.
 
-- [PNPM](https://pnpm.js.org/): A fundamentally new installation model that solves the ["phantom dependency" and "npm doppelganger"]({% link pages/advanced/phantom_deps.md %})" problems, while cleverly making use of [symlinks](https://en.wikipedia.org/wiki/Symbolic_link) to remain 100% compatible with the NodeJS module resolution standard.
+- [pnpm](https://pnpm.js.org/): A fundamentally new installation model that solves the ["phantom dependency" and "npm doppelganger"]({% link pages/advanced/phantom_deps.md %})" problems, while cleverly making use of [symlinks](https://en.wikipedia.org/wiki/Symbolic_link) to remain 100% compatible with the NodeJS module resolution standard.
 
 
 ## Which one should I use with Rush?
@@ -25,21 +25,21 @@ The answer depends on your needs.  The Rush developers don't endorse a particula
 
   *Before reporting a Rush bug involving the npm package manager, first try downgrading to `"npmVersion": "4.5.0"`.  If that eliminates the repro, then your issue is likely an npm regression and may not be fixable in the Rush code base.  We still accept these issues, but we track them differently.*
 
-#### Considerations for PNPM
+#### Considerations for pnpm
 
-- PNPM is the only option that solves the [npm doppelgangers]({% link pages/advanced/npm_doppelgangers.md %}) problem.  In a complex monorepo, doppelgangers sometimes cause a lot of trouble, so PNPM has an important advantage in this regard.
+- pnpm is the only option that solves the [npm doppelgangers]({% link pages/advanced/npm_doppelgangers.md %}) problem.  In a complex monorepo, doppelgangers sometimes cause a lot of trouble, so pnpm has an important advantage in this regard.
 
-- Although PNPM's symlinking strategy correctly follows the modern NodeJS module resolution standard, many legacy packages do not, which causes compatibility problems.  Teams who migrate existing projects from Yarn/npm to PNPM often encounter "bad packages" that need workarounds or fixes.  The incompatibilities generally reflect real problems with those packages: (1) forgetting to list dependencies in the **package.json** file, or (2) implementing homebrew module resolution without handling symlinks according to the standard.  Most "bad" packages have straightforward fixes, but it may seem daunting for a small team.  (The [PNPM Discord chat room](https://discord.gg/mThkzAT) is a great resource for help, though.)
+- Although pnpm's symlinking strategy correctly follows the modern NodeJS module resolution standard, many legacy packages do not, which causes compatibility problems.  Teams who migrate existing projects from Yarn/npm to pnpm often encounter "bad packages" that need workarounds or fixes.  The incompatibilities generally reflect real problems with those packages: (1) forgetting to list dependencies in the **package.json** file, or (2) implementing homebrew module resolution without handling symlinks according to the standard.  Most "bad" packages have straightforward fixes, but it may seem daunting for a small team.  (The [pnpm Discord chat room](https://discord.gg/mThkzAT) is a great resource for help, though.)
 
-- PNPM is newer and less widely used than npm or Yarn, but it's a solid piece of software.  Microsoft uses PNPM in Rush repos with hundreds of projects and hundreds of PRs per day, and we've found it to be very fast and reliable.
+- pnpm is newer and less widely used than npm or Yarn, but it's a solid piece of software.  Microsoft uses pnpm in Rush repos with hundreds of projects and hundreds of PRs per day, and we've found it to be very fast and reliable.
 
-- PNPM is currently the only option that supports the `--strict-peer-dependencies` protection (see `"strictPeerDependencies"` in **rush.json**).
+- pnpm is currently the only option that supports the `--strict-peer-dependencies` protection (see `"strictPeerDependencies"` in **rush.json**).
 
 #### Considerations for Yarn
 
 - Rush's support for Yarn is relatively new and unproven, so we're eager to hear about issues and get them fixed.
 
-- Yarn installs faster than npm (although somewhat slower than PNPM).
+- Yarn installs faster than npm (although somewhat slower than pnpm).
 
 - Yarn's "resolutions" feature is not yet compatible with Rush.  (See [Rush issue #831](https://github.com/microsoft/rushstack/issues/831).)
 

--- a/pages/maintainer/package_managers.md
+++ b/pages/maintainer/package_managers.md
@@ -1,37 +1,37 @@
 ---
 layout: page
-title: NPM vs PNPM vs Yarn
+title: npm vs PNPM vs Yarn
 navigation_source: docs_nav
 ---
 
 Before you can start installing a JavaScript library, you need to choose which package manager you will use.  (Our community loves flexibility and choices, so of course there's not just one!)  Rush supports the three most popular package managers.  In chronological order:
 
-- [NPM](https://docs.npmjs.com/getting-started/what-is-npm): the tool that pioneered the packaging standard and registry protocol used by most JavaScript package managers today.  The tool's developers also maintain the npmjs.com registry, which is currently the most popular place to distribute open source JavaScript libraries.
+- [npm](https://docs.npmjs.com/getting-started/what-is-npm): the tool that pioneered the packaging standard and registry protocol used by most JavaScript package managers today.  The tool's developers also maintain the npmjs.com registry, which is currently the most popular place to distribute open source JavaScript libraries.
 
-- [Yarn](https://yarnpkg.com/en/): a complete rewrite of the NPM tool that preserves the same installation model, but promises faster installations, better reliability, and some cool new features (e.g. Yarn workspaces) that facilitate large scale development.
+- [Yarn](https://yarnpkg.com/en/): a complete rewrite of the npm tool that preserves the same installation model, but promises faster installations, better reliability, and some cool new features (e.g. Yarn workspaces) that facilitate large scale development.
 
-- [PNPM](https://pnpm.js.org/): A fundamentally new installation model that solves the ["phantom dependency" and "NPM doppelganger"]({% link pages/advanced/phantom_deps.md %})" problems, while cleverly making use of [symlinks](https://en.wikipedia.org/wiki/Symbolic_link) to remain 100% compatible with the NodeJS module resolution standard.
+- [PNPM](https://pnpm.js.org/): A fundamentally new installation model that solves the ["phantom dependency" and "npm doppelganger"]({% link pages/advanced/phantom_deps.md %})" problems, while cleverly making use of [symlinks](https://en.wikipedia.org/wiki/Symbolic_link) to remain 100% compatible with the NodeJS module resolution standard.
 
 
 ## Which one should I use with Rush?
 
 The answer depends on your needs.  The Rush developers don't endorse a particular package manager, but here are some observations based on our experience from managing our own monorepos:
 
-#### Considerations for NPM
+#### Considerations for npm
 
-- NPM is the most compatible choice, and the most forgiving for dealing with "bad" packages.
+- npm is the most compatible choice, and the most forgiving for dealing with "bad" packages.
 
-- If you choose NPM, you may need to use an older release.  NPM 5.x and 6.x are both known to have unresolved regressions that cause trouble in Rush repos.  NPM **4.5.0** is the most recent version that's known to work very reliably, but unfortunately it's pretty old.  (We'd greatly appreciate community help improving this situation. We're using [GitHub issue #886](https://github.com/microsoft/rushstack/issues/886) to track this effort.)
+- If you choose npm, you may need to use an older release.  npm 5.x and 6.x are both known to have unresolved regressions that cause trouble in Rush repos.  npm **4.5.0** is the most recent version that's known to work very reliably, but unfortunately it's pretty old.  (We'd greatly appreciate community help improving this situation. We're using [GitHub issue #886](https://github.com/microsoft/rushstack/issues/886) to track this effort.)
 
-  *Before reporting a Rush bug involving the NPM package manager, first try downgrading to `"npmVersion": "4.5.0"`.  If that eliminates the repro, then your issue is likely an NPM regression and may not be fixable in the Rush code base.  We still accept these issues, but we track them differently.*
+  *Before reporting a Rush bug involving the npm package manager, first try downgrading to `"npmVersion": "4.5.0"`.  If that eliminates the repro, then your issue is likely an npm regression and may not be fixable in the Rush code base.  We still accept these issues, but we track them differently.*
 
 #### Considerations for PNPM
 
-- PNPM is the only option that solves the [NPM doppelgangers]({% link pages/advanced/npm_doppelgangers.md %}) problem.  In a complex monorepo, doppelgangers sometimes cause a lot of trouble, so PNPM has an important advantage in this regard.
+- PNPM is the only option that solves the [npm doppelgangers]({% link pages/advanced/npm_doppelgangers.md %}) problem.  In a complex monorepo, doppelgangers sometimes cause a lot of trouble, so PNPM has an important advantage in this regard.
 
-- Although PNPM's symlinking strategy correctly follows the modern NodeJS module resolution standard, many legacy packages do not, which causes compatibility problems.  Teams who migrate existing projects from Yarn/NPM to PNPM often encounter "bad packages" that need workarounds or fixes.  The incompatibilities generally reflect real problems with those packages: (1) forgetting to list dependencies in the **package.json** file, or (2) implementing homebrew module resolution without handling symlinks according to the standard.  Most "bad" packages have straightforward fixes, but it may seem daunting for a small team.  (The [PNPM Discord chat room](https://discord.gg/mThkzAT) is a great resource for help, though.)
+- Although PNPM's symlinking strategy correctly follows the modern NodeJS module resolution standard, many legacy packages do not, which causes compatibility problems.  Teams who migrate existing projects from Yarn/npm to PNPM often encounter "bad packages" that need workarounds or fixes.  The incompatibilities generally reflect real problems with those packages: (1) forgetting to list dependencies in the **package.json** file, or (2) implementing homebrew module resolution without handling symlinks according to the standard.  Most "bad" packages have straightforward fixes, but it may seem daunting for a small team.  (The [PNPM Discord chat room](https://discord.gg/mThkzAT) is a great resource for help, though.)
 
-- PNPM is newer and less widely used than NPM or Yarn, but it's a solid piece of software.  Microsoft uses PNPM in Rush repos with hundreds of projects and hundreds of PRs per day, and we've found it to be very fast and reliable.
+- PNPM is newer and less widely used than npm or Yarn, but it's a solid piece of software.  Microsoft uses PNPM in Rush repos with hundreds of projects and hundreds of PRs per day, and we've found it to be very fast and reliable.
 
 - PNPM is currently the only option that supports the `--strict-peer-dependencies` protection (see `"strictPeerDependencies"` in **rush.json**).
 
@@ -39,7 +39,7 @@ The answer depends on your needs.  The Rush developers don't endorse a particula
 
 - Rush's support for Yarn is relatively new and unproven, so we're eager to hear about issues and get them fixed.
 
-- Yarn installs faster than NPM (although somewhat slower than PNPM).
+- Yarn installs faster than npm (although somewhat slower than PNPM).
 
 - Yarn's "resolutions" feature is not yet compatible with Rush.  (See [Rush issue #831](https://github.com/microsoft/rushstack/issues/831).)
 

--- a/pages/maintainer/recommended_settings.md
+++ b/pages/maintainer/recommended_settings.md
@@ -54,8 +54,8 @@ installed for your repo.  For those exceptions, you can add an entry to the
 
 ## strictPeerDependencies
 
-If you're using the PNPM package manager, we strongly recommend setting `strictPeerDependencies`
-to `true` in **rush.json**.  This causes Rush to use PNPM's `--strict-peer-dependencies` option
+If you're using the pnpm package manager, we strongly recommend setting `strictPeerDependencies`
+to `true` in **rush.json**.  This causes Rush to use pnpm's `--strict-peer-dependencies` option
 during installation.  With this protection, `rush install` will fail if there are unsatisfied
 peer dependencies, which is an invalid state that can cause build failures or incompatible
 dependency versions.  (For historical reasons, JavaScript package managers generally do not treat

--- a/pages/maintainer/setup_new_repo.md
+++ b/pages/maintainer/setup_new_repo.md
@@ -38,7 +38,7 @@ Before we get started, make sure you have the latest Rush release installed glob
 ~$ npm install -g @microsoft/rush
 ```
 
-*NOTE: If this command fails because your user account does not have permissions to access NPM's global folder, you may need to [fix your NPM configuration](https://docs.npmjs.com/getting-started/fixing-npm-permissions).*
+*NOTE: If this command fails because your user account does not have permissions to access npm's global folder, you may need to [fix your npm configuration](https://docs.npmjs.com/getting-started/fixing-npm-permissions).*
 
 ## Step 2: Use "rush init" to initialize your repo
 
@@ -58,10 +58,10 @@ It will generate these files (see [Config file reference]({% link pages/advanced
 | **.gitattributes** | *(Delete this file if you're not using Git.)* <br/>Tells Git not to perform merging operations for shrinkwrap files, because it is unsafe. |
 | **.gitignore** | *(Delete this file if you're not using Git.)* <br/>Tells Git not to track temporary files created by Rush. |
 | **.travis.yml** | *(Delete this file if you're not using Travis.)* <br/>Configures the [Travis CI](https://travis-ci.com/) service to perform PR builds using Rush. |
-| **common/config/rush/.npmrc** | Rush uses this file to configure the package registry, regardless of whether the package manager is PNPM, NPM, or Yarn. |
+| **common/config/rush/.npmrc** | Rush uses this file to configure the package registry, regardless of whether the package manager is PNPM, npm, or Yarn. |
 | **common/config/rush/command-line.json** | You can use this to define custom commands/parameters that will become part of the Rush command-line. |
-| **common/config/rush/common-versions.json** | Used to specify NPM dependency version selections that affect all projects in a Rush repo. |
-| **common/config/rush/pnpmfile.js** | *(Delete this file if you've chosen to use NPM or Yarn instead of PNPM.)* <br/>Used to workaround problems with dependencies that have mistakes in their package.json file. |
+| **common/config/rush/common-versions.json** | Used to specify npm dependency version selections that affect all projects in a Rush repo. |
+| **common/config/rush/pnpmfile.js** | *(Delete this file if you've chosen to use npm or Yarn instead of PNPM.)* <br/>Used to workaround problems with dependencies that have mistakes in their package.json file. |
 | **common/config/rush/version-policies.json** | Used to define advanced publishing configurations. |
 
 **NOTE: If any of these files already exists in your branch, `rush init` will issue a warning and will NOT overwrite the existing files.**
@@ -79,15 +79,15 @@ The template files have lots of documentation and commented example snippets.  W
 
 You can change your options at any time, but there are a few settings in **rush.json** that you should think about in advance:
 
-- **Choose a package manager**: The template defaults to using PNPM, but you can also use NPM or Yarn.  See [NPM vs PNPM vs Yarn]({% link pages/maintainer/package_managers.md %}) for guidance.
+- **Choose a package manager**: The template defaults to using PNPM, but you can also use npm or Yarn.  See [npm vs PNPM vs Yarn]({% link pages/maintainer/package_managers.md %}) for guidance.
 
-- **Check your Rush version**: Make sure your `rushVersion` setting is the latest version, which is shown in the [NPM registry](https://www.npmjs.com/package/@microsoft/rush).
+- **Check your Rush version**: Make sure your `rushVersion` setting is the latest version, which is shown in the [npm registry](https://www.npmjs.com/package/@microsoft/rush).
 
 - **Check other version fields**: Also check that you're using recent stable releases for any other applicable fields such as `pnpmVersion`, `npmVersion`, `yarnVersion`, `nodeSupportedVersionRange`
 
 - **Decide whether to use the "category folders" model**: See the comments in **rush.json** regarding `projectFolderMinDepth` and `projectFolderMaxDepth`, and make a plan for how project folders will be organized in the monorepo
 
-- **Configure your registry access**: The initial **.npmrc** file is configured to use the public NPM registry.  If you will be using a [private registry]({% link pages/maintainer/npm_registry_auth.md %}), you should update the **common/config/rush/.npmrc** file.
+- **Configure your registry access**: The initial **.npmrc** file is configured to use the public npm registry.  If you will be using a [private registry]({% link pages/maintainer/npm_registry_auth.md %}), you should update the **common/config/rush/.npmrc** file.
 
 
 #### Next up: [Adding projects to a repo]({% link pages/maintainer/add_to_repo.md %})

--- a/pages/maintainer/setup_new_repo.md
+++ b/pages/maintainer/setup_new_repo.md
@@ -58,10 +58,10 @@ It will generate these files (see [Config file reference]({% link pages/advanced
 | **.gitattributes** | *(Delete this file if you're not using Git.)* <br/>Tells Git not to perform merging operations for shrinkwrap files, because it is unsafe. |
 | **.gitignore** | *(Delete this file if you're not using Git.)* <br/>Tells Git not to track temporary files created by Rush. |
 | **.travis.yml** | *(Delete this file if you're not using Travis.)* <br/>Configures the [Travis CI](https://travis-ci.com/) service to perform PR builds using Rush. |
-| **common/config/rush/.npmrc** | Rush uses this file to configure the package registry, regardless of whether the package manager is PNPM, npm, or Yarn. |
+| **common/config/rush/.npmrc** | Rush uses this file to configure the package registry, regardless of whether the package manager is pnpm, npm, or Yarn. |
 | **common/config/rush/command-line.json** | You can use this to define custom commands/parameters that will become part of the Rush command-line. |
 | **common/config/rush/common-versions.json** | Used to specify npm dependency version selections that affect all projects in a Rush repo. |
-| **common/config/rush/pnpmfile.js** | *(Delete this file if you've chosen to use npm or Yarn instead of PNPM.)* <br/>Used to workaround problems with dependencies that have mistakes in their package.json file. |
+| **common/config/rush/pnpmfile.js** | *(Delete this file if you've chosen to use npm or Yarn instead of pnpm.)* <br/>Used to workaround problems with dependencies that have mistakes in their package.json file. |
 | **common/config/rush/version-policies.json** | Used to define advanced publishing configurations. |
 
 **NOTE: If any of these files already exists in your branch, `rush init` will issue a warning and will NOT overwrite the existing files.**
@@ -79,7 +79,7 @@ The template files have lots of documentation and commented example snippets.  W
 
 You can change your options at any time, but there are a few settings in **rush.json** that you should think about in advance:
 
-- **Choose a package manager**: The template defaults to using PNPM, but you can also use npm or Yarn.  See [npm vs PNPM vs Yarn]({% link pages/maintainer/package_managers.md %}) for guidance.
+- **Choose a package manager**: The template defaults to using pnpm, but you can also use npm or Yarn.  See [npm vs pnpm vs Yarn]({% link pages/maintainer/package_managers.md %}) for guidance.
 
 - **Check your Rush version**: Make sure your `rushVersion` setting is the latest version, which is shown in the [npm registry](https://www.npmjs.com/package/@microsoft/rush).
 

--- a/pages/maintainer/setup_policies.md
+++ b/pages/maintainer/setup_policies.md
@@ -80,9 +80,9 @@ To fix it, you can use commands like this:
 Aborting, so you can go fix your settings.  (Or use --bypass-policy to skip.)
 ```
 
-## approvedPackagesPolicy: Reviewing new NPM dependencies
+## approvedPackagesPolicy: Reviewing new npm dependencies
 
-Are there certain people on your team who constantly find exciting new libraries and add them to your package.json?  This can quickly get out of hand, especially in environments that require legal or security reviews for external code.  The **approvedPackagesPolicy** feature allows you to detect when new NPM dependencies are introduced.
+Are there certain people on your team who constantly find exciting new libraries and add them to your package.json?  This can quickly get out of hand, especially in environments that require legal or security reviews for external code.  The **approvedPackagesPolicy** feature allows you to detect when new npm dependencies are introduced.
 
 Since different levels of scrutiny are often required (e.g. for a shipping product, versus an intern project, versus an internal library), we distinguish "review categories".  This allows us to approve a package once for an entire category of projects, while still being alerted when the dependency is used somewhere else.
 
@@ -149,7 +149,7 @@ After running `rush install`, the **browser-approved-packages.json** file will l
 
 For example, this file is showing that the external dependency **@microsoft/gulp-core-build** was found in the package.json file for an "internal" project (let's say **~/demo/lib1**) but not any "public" project (such as **~/demo/application**).
 
-Rush has no way to detect whether an NPM package is for the browser or not.  Since these are all non-browser files, you must manually move them to the other file **browser-approved-packages.json**.
+Rush has no way to detect whether an npm package is for the browser or not.  Since these are all non-browser files, you must manually move them to the other file **browser-approved-packages.json**.
 
 #### How approvals work
 

--- a/permalinks/home.html
+++ b/permalinks/home.html
@@ -96,16 +96,16 @@ permalink: /
       <div class="card m-4">
         <div class="row no-gutters">
           <div class="col-md-auto p-3 home-card">
-            <img src="/images/home/card-phantom.svg" class="img-fluid mx-auto d-block" alt="NPM phantom dependency" />
+            <img src="/images/home/card-phantom.svg" class="img-fluid mx-auto d-block" alt="npm phantom dependency" />
           </div>
           <div class="col-md p-3">
             <div class="card-block px-2">
               <h4 class="card-title">No phantom dependencies!</h4>
               <p class="card-text">Tired of broken imports or mismatched versions when someone else installs
-              your package?  Rush's isolated symlinking model eliminates these NPM
+              your package?  Rush's isolated symlinking model eliminates these npm
               <a href="{% link pages/advanced/phantom_deps.md %}">phantom dependencies</a>,
               ensuring you'll never again accidentally import a library that was missing from package.json.</p>
-              <p>This algorithm is compatible with <b>PNPM</b>, <b>NPM</b>, and <b>Yarn</b> package managers.</p>
+              <p>This algorithm is compatible with <b>PNPM</b>, <b>npm</b>, and <b>Yarn</b> package managers.</p>
             </div>
           </div>
         </div>
@@ -114,13 +114,13 @@ permalink: /
       <div class="card m-4">
         <div class="row no-gutters">
           <div class="col-md-auto p-3 order-md-2 home-card">
-            <img src="/images/home/card-doppel.svg" class="img-fluid mx-auto d-block" alt="NPM doppelganger" />
+            <img src="/images/home/card-doppel.svg" class="img-fluid mx-auto d-block" alt="npm doppelganger" />
           </div>
           <div class="col-md p-3">
             <div class="card-block px-2">
-              <h4 class="card-title">No NPM doppelgangers!</h4>
+              <h4 class="card-title">No npm doppelgangers!</h4>
               <p class="card-text">Rush's installation model now supports the <b>PNPM</b> package manager,
-              which eliminates <a href="{% link pages/advanced/npm_doppelgangers.md %}">NPM doppelgangers</a>.
+              which eliminates <a href="{% link pages/advanced/npm_doppelgangers.md %}">npm doppelgangers</a>.
               You'll never again find 5 copies of the same version of the same library in your node_modules folder!</p>
             </div>
           </div>

--- a/permalinks/home.html
+++ b/permalinks/home.html
@@ -105,7 +105,7 @@ permalink: /
               your package?  Rush's isolated symlinking model eliminates these npm
               <a href="{% link pages/advanced/phantom_deps.md %}">phantom dependencies</a>,
               ensuring you'll never again accidentally import a library that was missing from package.json.</p>
-              <p>This algorithm is compatible with <b>PNPM</b>, <b>npm</b>, and <b>Yarn</b> package managers.</p>
+              <p>This algorithm is compatible with <b>pnpm</b>, <b>npm</b>, and <b>Yarn</b> package managers.</p>
             </div>
           </div>
         </div>
@@ -119,7 +119,7 @@ permalink: /
           <div class="col-md p-3">
             <div class="card-block px-2">
               <h4 class="card-title">No npm doppelgangers!</h4>
-              <p class="card-text">Rush's installation model now supports the <b>PNPM</b> package manager,
+              <p class="card-text">Rush's installation model now supports the <b>pnpm</b> package manager,
               which eliminates <a href="{% link pages/advanced/npm_doppelgangers.md %}">npm doppelgangers</a>.
               You'll never again find 5 copies of the same version of the same library in your node_modules folder!</p>
             </div>


### PR DESCRIPTION
I'm part of the engineering team at npm and wanted to quickly contribute this to use the correct spelling of npm which is always all lowercase, compare also https://github.com/npm/cli#is-it-npm-or-npm-or-npm 