### PR TITLE
Remove a recommendation from "Authoring change logs" page

### DIFF
--- a/pages/best_practices/change_logs.md
+++ b/pages/best_practices/change_logs.md
@@ -49,8 +49,6 @@ In some workflows, a human editor will review the change logs before they are pu
 
 - Don't add a trailing period unless you have two or more sentences.
 
-- Use the word "function" instead of "method".
-
 ## Example Change Log Messages
 
 Here are some hypothetical change log messages that might be provided to `rush change`:


### PR DESCRIPTION
Remove recommendation to use the word "function" rather than "method", as it is frequently inaccurate and in conflict with existing verbiage in API Extractor