### PR TITLE
Update env variable in installation_variants.md

### DIFF
--- a/pages/advanced/installation_variants.md
+++ b/pages/advanced/installation_variants.md
@@ -139,7 +139,7 @@ $ rush rebuild
 ```
 
 ⏵ If you get tired of typing `--variant`, you can also use the
-[RUSH_PREVIEW_VERSION]({% link pages/configs/environment_vars.md %})
+[RUSH_VARIANT]({% link pages/configs/environment_vars.md %})
 environment variable to specify the variant name.
 
 **5<!-- -->. Restoring the original state.**  When you're done testing your variant, you can return to the original


### PR DESCRIPTION
While reading the documentation I have found a small mistake:

The environment variable mentioned in the "[Installation variants](https://rushjs.io/pages/advanced/installation_variants/)" documentation page is wrong.
It is `RUSH_PREVIEW_VERSION` but should be `RUSH_VARIANT` as mentioned [here](https://rushjs.io/pages/configs/environment_vars/#rush_variant).